### PR TITLE
More e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,5 +112,6 @@ jobs:
 
       - name: Run e2e tests
         run: pnpm test:e2e
+        timeout-minutes: 5
         env:
           DATABASE_URL: postgresql://wf:wf@localhost:5434/workflow

--- a/e2e/app/api/trigger-e2e/route.ts
+++ b/e2e/app/api/trigger-e2e/route.ts
@@ -1,0 +1,53 @@
+import { start } from 'workflow/api'
+import { NextResponse } from 'next/server'
+import {
+  addTenWorkflow,
+  promiseAllWorkflow,
+  promiseRaceWorkflow,
+  sleepingWorkflow,
+  parallelSleepWorkflow,
+  nullByteWorkflow,
+  fetchWorkflow,
+  errorRetrySuccessWorkflow,
+  errorFatalWorkflow,
+  hookWorkflow,
+  webhookWorkflow,
+  spawnWorkflowFromStepWorkflow,
+} from '@/workflows/e2e'
+
+const workflows: Record<string, (...args: any[]) => any> = {
+  addTenWorkflow,
+  promiseAllWorkflow,
+  promiseRaceWorkflow,
+  sleepingWorkflow,
+  parallelSleepWorkflow,
+  nullByteWorkflow,
+  fetchWorkflow,
+  errorRetrySuccessWorkflow,
+  errorFatalWorkflow,
+  hookWorkflow,
+  webhookWorkflow,
+  spawnWorkflowFromStepWorkflow,
+}
+
+export async function POST (request: Request) {
+  const { workflow, args = [], waitForResult } = await request.json() as {
+    workflow: string
+    args?: any[]
+    waitForResult?: boolean
+  }
+
+  const fn = workflows[workflow]
+  if (!fn) {
+    return NextResponse.json({ error: `Unknown workflow: ${workflow}` }, { status: 400 })
+  }
+
+  const run = await start(fn, args)
+
+  if (waitForResult) {
+    const result = await run.returnValue
+    return NextResponse.json({ runId: run.runId, result })
+  }
+
+  return NextResponse.json({ runId: run.runId })
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev --turbopack -p 3456",
     "build": "next build",
-    "test": "node --test test/*.test.ts"
+    "test": "node --test --test-force-exit test/*.test.ts"
   },
   "dependencies": {
     "@platformatic/world": "workspace:*",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -17,7 +17,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.0",
+    "@types/pg": "^8.18.0",
     "@types/react": "^19.0.0",
+    "pg": "^8.20.0",
     "typescript": "^5.9.3"
   }
 }

--- a/e2e/test/workflow.test.ts
+++ b/e2e/test/workflow.test.ts
@@ -75,6 +75,28 @@ async function waitForRunStatus (runId: string, status: string, timeoutMs = 30_0
   throw new Error(`Timed out waiting for run ${runId} to reach status ${status}`)
 }
 
+async function triggerE2eWorkflow (workflow: string, args: any[] = []): Promise<string> {
+  const res = await fetch(`${NEXT_URL}/api/trigger-e2e`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ workflow, args }),
+  })
+  assert.equal(res.status, 200, `trigger ${workflow} failed: ${res.status}`)
+  const { runId } = await res.json() as { runId: string }
+  assert.ok(runId, `${workflow} should return a runId`)
+  return runId
+}
+
+async function runE2eWorkflow (workflow: string, args: any[] = []): Promise<{ runId: string, result: any }> {
+  const res = await fetch(`${NEXT_URL}/api/trigger-e2e`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ workflow, args, waitForResult: true }),
+  })
+  assert.equal(res.status, 200, `trigger ${workflow} failed: ${res.status}`)
+  return await res.json() as { runId: string, result: any }
+}
+
 async function registerHandlers (): Promise<void> {
   const res = await fetch(`${WF_URL}/api/v1/apps/default/handlers`, {
     method: 'POST',
@@ -98,6 +120,13 @@ let wfService: SpawnedProcess
 let nextApp: SpawnedProcess
 
 before(async () => {
+  // 0. Clean up the database from any previous test runs
+  const { default: pg } = await import('pg')
+  const client = new pg.Client(DB_URL)
+  await client.connect()
+  await client.query('TRUNCATE workflow_events, workflow_hooks, workflow_queue_messages, workflow_steps, workflow_waits, workflow_stream_chunks, workflow_runs, workflow_queue_handlers CASCADE')
+  await client.end()
+
   // 1. Start the workflow service in single-tenant mode
   wfService = startProcess('node', ['src/server.ts'], {
     DATABASE_URL: DB_URL,
@@ -152,4 +181,70 @@ test('workflow service has the run with events', { timeout: 10_000 }, async () =
   assert.equal(eventsRes.status, 200)
   const { data: events } = await eventsRes.json() as { data: any[] }
   assert.ok(events.length >= 2, 'should have at least run_created and run_completed events')
+})
+
+// ---- Vercel e2e compatibility tests ----
+
+test('addTen: multi-step chaining', { timeout: 30_000 }, async () => {
+  const { result } = await runE2eWorkflow('addTenWorkflow', [5])
+  assert.equal(result, 15)
+})
+
+test('promiseAll: parallel steps', { timeout: 30_000 }, async () => {
+  const { result } = await runE2eWorkflow('promiseAllWorkflow')
+  assert.equal(result, 'ABC')
+})
+
+test('promiseRace: first step wins', { timeout: 60_000 }, async () => {
+  const { result } = await runE2eWorkflow('promiseRaceWorkflow')
+  assert.equal(result, 'B')
+})
+
+test('sleeping: deferred delivery', { timeout: 60_000 }, async () => {
+  const startTime = Date.now()
+  const runId = await triggerE2eWorkflow('sleepingWorkflow')
+  const run = await waitForRunStatus(runId, 'completed', 45_000)
+  const elapsed = Date.now() - startTime
+  assert.equal(run.status, 'completed')
+  assert.ok(elapsed >= 9_000, `sleep should be at least 9s, got ${elapsed}ms`)
+})
+
+test('parallelSleep: concurrent sleeps', { timeout: 30_000 }, async () => {
+  const startTime = Date.now()
+  const runId = await triggerE2eWorkflow('parallelSleepWorkflow')
+  const run = await waitForRunStatus(runId, 'completed', 20_000)
+  const elapsed = Date.now() - startTime
+  assert.equal(run.status, 'completed')
+  // 10 parallel 1s sleeps should complete in ~2-3s, not 10s
+  assert.ok(elapsed < 8_000, `parallel sleeps should overlap, took ${elapsed}ms`)
+})
+
+test('nullByte: data integrity', { timeout: 30_000 }, async () => {
+  const { result } = await runE2eWorkflow('nullByteWorkflow')
+  assert.equal(result, 'null byte \0')
+})
+
+test('fetch: network inside step', { timeout: 30_000 }, async () => {
+  const { result } = await runE2eWorkflow('fetchWorkflow')
+  assert.equal(result.userId, 1)
+  assert.equal(result.id, 1)
+  assert.ok(result.title)
+})
+
+test('errorRetry: step retries until success', { timeout: 60_000 }, async () => {
+  const { result } = await runE2eWorkflow('errorRetrySuccessWorkflow')
+  assert.equal(result.finalAttempt, 3)
+})
+
+test('errorFatal: no retries on FatalError', { timeout: 30_000 }, async () => {
+  const { result } = await runE2eWorkflow('errorFatalWorkflow')
+  assert.equal(result.caught, true)
+  assert.equal(result.message, 'Fatal step error')
+})
+
+test('spawnWorkflowFromStep: child workflow', { timeout: 60_000 }, async () => {
+  const { result } = await runE2eWorkflow('spawnWorkflowFromStepWorkflow', [7])
+  assert.equal(result.parentInput, 7)
+  assert.equal(result.childResult.childResult, 14)
+  assert.ok(result.childRunId)
 })

--- a/e2e/test/workflow.test.ts
+++ b/e2e/test/workflow.test.ts
@@ -120,20 +120,20 @@ let wfService: SpawnedProcess
 let nextApp: SpawnedProcess
 
 before(async () => {
-  // 0. Clean up the database from any previous test runs
-  const { default: pg } = await import('pg')
-  const client = new pg.Client(DB_URL)
-  await client.connect()
-  await client.query('TRUNCATE workflow_events, workflow_hooks, workflow_queue_messages, workflow_steps, workflow_waits, workflow_stream_chunks, workflow_runs, workflow_queue_handlers CASCADE')
-  await client.end()
-
-  // 1. Start the workflow service in single-tenant mode
+  // 1. Start the workflow service in single-tenant mode (runs migrations, creates tables)
   wfService = startProcess('node', ['src/server.ts'], {
     DATABASE_URL: DB_URL,
     PORT: String(WF_PORT),
   }, WORKFLOW_ROOT)
 
   await waitForReady(`${WF_URL}/status`)
+
+  // 2. Clean up stale data from any previous test runs (tables exist after migrations)
+  const { default: pg } = await import('pg')
+  const client = new pg.Client(DB_URL)
+  await client.connect()
+  await client.query('TRUNCATE workflow_events, workflow_hooks, workflow_queue_messages, workflow_steps, workflow_waits, workflow_stream_chunks, workflow_runs, workflow_queue_handlers CASCADE')
+  await client.end()
 
   // 2. Start the Next.js app (already built)
   nextApp = startProcess('npx', ['next', 'start', '-p', String(NEXT_PORT)], {

--- a/e2e/workflows/e2e.ts
+++ b/e2e/workflows/e2e.ts
@@ -1,0 +1,203 @@
+import { sleep, FatalError, createHook, createWebhook, type RequestWithResponse, fetch } from 'workflow'
+import { start } from 'workflow/api'
+
+// ---- addTen: multi-step chaining ----
+
+async function add (a: number, b: number) {
+  'use step'
+  return a + b
+}
+
+export async function addTenWorkflow (input: number) {
+  'use workflow'
+  const a = await add(input, 2)
+  const b = await add(a, 3)
+  const c = await add(b, 5)
+  return c
+}
+
+// ---- promiseAll: parallel steps ----
+
+async function randomDelay (v: string) {
+  'use step'
+  await new Promise((resolve) => setTimeout(resolve, Math.random() * 500))
+  return v.toUpperCase()
+}
+
+export async function promiseAllWorkflow () {
+  'use workflow'
+  const [a, b, c] = await Promise.all([
+    randomDelay('a'),
+    randomDelay('b'),
+    randomDelay('c'),
+  ])
+  return a + b + c
+}
+
+// ---- promiseRace: first step wins ----
+
+async function specificDelay (delay: number, v: string) {
+  'use step'
+  await new Promise((resolve) => setTimeout(resolve, delay))
+  return v.toUpperCase()
+}
+
+export async function promiseRaceWorkflow () {
+  'use workflow'
+  const winner = await Promise.race([
+    specificDelay(10000, 'a'),
+    specificDelay(100, 'b'),
+    specificDelay(20000, 'c'),
+  ])
+  return winner
+}
+
+// ---- sleeping: deferred delivery ----
+
+export async function sleepingWorkflow () {
+  'use workflow'
+  const startTime = Date.now()
+  await sleep('10s')
+  const endTime = Date.now()
+  return { startTime, endTime }
+}
+
+// ---- parallel sleep ----
+
+export async function parallelSleepWorkflow () {
+  'use workflow'
+  const startTime = Date.now()
+  await Promise.all(Array.from({ length: 10 }, () => sleep('1s')))
+  const endTime = Date.now()
+  return { startTime, endTime }
+}
+
+// ---- null byte: data integrity ----
+
+async function returnNullByte () {
+  'use step'
+  return 'null byte \0'
+}
+
+export async function nullByteWorkflow () {
+  'use workflow'
+  return await returnNullByte()
+}
+
+// ---- fetch: network inside step ----
+
+async function fetchTodo () {
+  'use step'
+  const res = await fetch('https://jsonplaceholder.typicode.com/todos/1')
+  return res.json()
+}
+
+export async function fetchWorkflow () {
+  'use workflow'
+  return await fetchTodo()
+}
+
+// ---- error retry: step retries until success ----
+
+let retryAttempt = 0
+
+async function retryUntilAttempt3 () {
+  'use step'
+  retryAttempt++
+  if (retryAttempt < 3) {
+    throw new Error('not yet')
+  }
+  return { finalAttempt: retryAttempt }
+}
+
+export async function errorRetrySuccessWorkflow () {
+  'use workflow'
+  retryAttempt = 0
+  return await retryUntilAttempt3()
+}
+
+// ---- fatal error: no retries ----
+
+async function throwFatalError () {
+  'use step'
+  throw new FatalError('Fatal step error')
+}
+
+export async function errorFatalWorkflow () {
+  'use workflow'
+  try {
+    await throwFatalError()
+    return { caught: false }
+  } catch (e: any) {
+    return { caught: true, message: e.message }
+  }
+}
+
+// ---- hook workflow: pause and resume ----
+
+export async function hookWorkflow (token: string, customData: string) {
+  'use workflow'
+  const results: any[] = []
+
+  const hook = createHook({ token, metadata: { customData } })
+
+  for await (const payload of hook) {
+    results.push(payload)
+    if (payload.done) break
+  }
+
+  return results
+}
+
+// ---- webhook workflow: HTTP-triggered resume ----
+
+export async function webhookWorkflow () {
+  'use workflow'
+  const results: any[] = []
+
+  const webhook1 = createWebhook()
+  const webhook2 = createWebhook({
+    respondWith: new Response('Hello from static response!', { status: 402 }),
+  })
+  const webhook3 = createWebhook({
+    respondWith: 'manual',
+  })
+
+  const payload1 = await webhook1
+  results.push({ url: webhook1.url, method: payload1.method })
+
+  const payload2 = await webhook2
+  results.push({ url: webhook2.url, method: payload2.method })
+
+  const payload3 = await webhook3 as unknown as RequestWithResponse
+  await payload3.respondWith(new Response('Hello from webhook!', { status: 200 }))
+  results.push({ url: webhook3.url, method: payload3.method })
+
+  return results
+}
+
+// ---- spawn child workflow from step ----
+
+async function doubleValue (input: number) {
+  'use step'
+  return input * 2
+}
+
+async function childWorkflow (input: number) {
+  'use workflow'
+  const result = await doubleValue(input)
+  return { childResult: result, originalValue: input }
+}
+
+async function spawnChild (input: number) {
+  'use step'
+  const run = await start(childWorkflow, [input])
+  const result = await run.returnValue
+  return { childRunId: run.runId, childResult: result }
+}
+
+export async function spawnWorkflowFromStepWorkflow (input: number) {
+  'use workflow'
+  const { childRunId, childResult } = await spawnChild(input)
+  return { parentInput: input, childRunId, childResult }
+}

--- a/packages/world/src/lib/queue.ts
+++ b/packages/world/src/lib/queue.ts
@@ -7,15 +7,23 @@ export interface QueueConfig {
 
 export function createQueue (client: HttpClient, config: QueueConfig) {
   const queue = async (queueName: ValidQueueName, message: QueuePayload, opts?: QueueOptions): Promise<{ messageId: MessageId | null }> => {
-    const result = await client.post('/queue', {
-      queueName,
-      message,
-      deploymentId: opts?.deploymentId ?? config.deploymentVersion,
-      idempotencyKey: opts?.idempotencyKey,
-      delaySeconds: opts?.delaySeconds,
-    })
+    try {
+      const result = await client.post('/queue', {
+        queueName,
+        message,
+        deploymentId: opts?.deploymentId ?? config.deploymentVersion,
+        idempotencyKey: opts?.idempotencyKey,
+        delaySeconds: opts?.delaySeconds,
+      })
 
-    return { messageId: (result?.messageId ?? null) as MessageId | null }
+      return { messageId: (result?.messageId ?? null) as MessageId | null }
+    } catch (err: any) {
+      // 409 = duplicate idempotency key, treat as success (message already processed)
+      if (err.statusCode === 409) {
+        return { messageId: null }
+      }
+      throw err
+    }
   }
 
   const createQueueHandler = (_prefix: string, handler: (message: unknown, meta: { attempt: number; queueName: ValidQueueName; messageId: MessageId }) => Promise<void | { timeoutSeconds: number }>) => {

--- a/packages/world/src/lib/storage.ts
+++ b/packages/world/src/lib/storage.ts
@@ -65,6 +65,9 @@ function coerceDates (obj: any): any {
 function restoreEntity (obj: any): any {
   if (!obj) return obj
   coerceDates(obj)
+  if (obj.eventData && typeof obj.eventData === 'object') {
+    coerceDates(obj.eventData)
+  }
   restoreUint8Arrays(obj)
   return obj
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,15 @@ importers:
       '@types/node':
         specifier: ^22.15.0
         version: 22.19.15
+      '@types/pg':
+        specifier: ^8.18.0
+        version: 8.18.0
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
Add comprehensive e2e tests matching Vercel's workflow SDK test suite, and fix two bugs in `@platformatic/world` discovered during testing.

### E2E tests added (10 new test cases)

- **addTen** — multi-step chaining (5 + 2 + 3 + 5 = 15)
- **promiseAll** — parallel steps with random delays
- **promiseRace** — first step wins
- **sleeping** — deferred delivery via `sleep('10s')`
- **parallelSleep** — 10 concurrent 1s sleeps complete in ~1-2s
- **nullByte** — data integrity with null bytes in output
- **fetch** — network calls inside steps
- **errorRetry** — step retries until success on attempt 3
- **errorFatal** — `FatalError` caught without retries
- **spawnWorkflowFromStep** — child workflow spawned from a step via `start()`

A generic `/api/trigger-e2e` route allows starting any workflow by name with optional `waitForResult` to return the decrypted output.

### Bug fixes in `@platformatic/world`

1. **queue: handle 409 idempotency conflicts** — The Vercel SDK replays queue messages during workflow recovery. A 409 (duplicate idempotency key) is expected and means the message was already processed. Previously `queue()` threw on 409; now it returns `{ messageId: null }` (success).

2. **storage: coerce dates inside `eventData`** — `coerceDates()` only ran on top-level entity fields, not nested `eventData`. The SDK expects `event.eventData.resumeAt` to be a `Date` object (calls `.getTime()`), but it was returned as an ISO string. This broke `sleep()` workflows. Fixed by also calling `coerceDates()` on `eventData`.