### PR TITLE
fix: restore Watt migration and add publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/packages/workflow/Dockerfile
+++ b/packages/workflow/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:24-slim
+
+RUN npm install -g pnpm@10
+
+WORKDIR /app
+
+COPY package.json ./
+RUN pnpm install --prod
+
+COPY watt.json ./
+COPY plugins/ ./plugins/
+COPY lib/ ./lib/
+COPY queue/ ./queue/
+COPY migrations/ ./migrations/
+
+EXPOSE 3042
+
+ENV PORT=3042
+ENV HOST=0.0.0.0
+
+CMD ["npx", "wattpm", "start"]

--- a/packages/workflow/lib/auth/index.ts
+++ b/packages/workflow/lib/auth/index.ts
@@ -1,0 +1,123 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
+import { createK8sTokenValidator } from './k8s-token.ts'
+import { Unauthorized, Forbidden } from '../errors.ts'
+
+export interface AuthConfig {
+  mode: 'k8s-token' | 'none'
+  defaultAppId?: number
+  k8s?: {
+    apiServer: string
+    caCert?: string
+    adminServiceAccount?: string
+  }
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    appId: number
+    isAdmin: boolean
+  }
+}
+
+// Paths that skip auth entirely (health/metrics are on the Watt metrics port)
+const PUBLIC_PATHS = new Set<string>()
+
+// Paths that require admin access (not app-level auth)
+function isAdminPath (url: string): boolean {
+  return (url.startsWith('/api/v1/apps') && (
+    url.endsWith('/k8s-binding') ||
+    url.match(/^\/api\/v1\/apps\/?$/) !== null
+  )) || url.startsWith('/api/v1/versions/')
+}
+
+async function authPlugin (app: FastifyInstance, config: AuthConfig): Promise<void> {
+  app.decorateRequest('appId', 0)
+  app.decorateRequest('isAdmin', false)
+
+  // No-auth mode: set appId from config and skip all token parsing
+  if (config.mode === 'none') {
+    app.addHook('onRequest', async (request: FastifyRequest) => {
+      request.appId = config.defaultAppId || 0
+      request.isAdmin = true
+    })
+    return
+  }
+
+  const validateK8s = config.k8s
+    ? createK8sTokenValidator(app.pg, config.k8s)
+    : null
+
+  app.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
+    const url = request.url.split('?')[0]
+
+    if (PUBLIC_PATHS.has(url)) return
+
+    const authHeader = request.headers.authorization
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new Unauthorized('missing or invalid Authorization header')
+    }
+
+    const token = authHeader.slice(7)
+
+    let applicationId: number | null = null
+
+    if (validateK8s) {
+      const k8sResult = await validateK8s(token)
+      if (k8sResult) {
+        applicationId = k8sResult.applicationId
+        if (k8sResult.isAdmin) {
+          request.isAdmin = true
+        }
+      }
+    }
+
+    if (applicationId === null && !request.isAdmin) {
+      if (isAdminPath(url)) {
+        throw new Forbidden('admin access required')
+      }
+      throw new Unauthorized('invalid credentials')
+    }
+
+    if (applicationId !== null) {
+      request.appId = applicationId
+    }
+
+    // Admin can access app-scoped endpoints when appId is in URL
+    if (request.isAdmin && applicationId === null) {
+      const appIdMatch = url.match(/\/api\/v1\/apps\/([^/]+)/)
+      if (appIdMatch) {
+        const result = await app.pg.query(
+          'SELECT id FROM workflow_applications WHERE app_id = $1',
+          [appIdMatch[1]]
+        )
+        if (result.rows.length > 0) {
+          request.appId = result.rows[0].id
+        }
+      }
+      return
+    }
+
+    // Admin-only endpoints reject non-admin tokens
+    if (isAdminPath(url) && !request.isAdmin) {
+      throw new Forbidden('admin access required')
+    }
+
+    // Verify URL appId matches auth-derived appId
+    const appIdMatch = url.match(/\/api\/v1\/apps\/([^/]+)/)
+    if (appIdMatch) {
+      const result = await app.pg.query(
+        'SELECT id FROM workflow_applications WHERE app_id = $1',
+        [appIdMatch[1]]
+      )
+      if (result.rows.length === 0 || result.rows[0].id !== applicationId) {
+        throw new Forbidden('app ID mismatch')
+      }
+    }
+  })
+}
+
+// Break encapsulation so decorators and hooks propagate to sibling plugins
+const skipOverride = Symbol.for('skip-override')
+;(authPlugin as any)[skipOverride] = true
+
+export default authPlugin

--- a/packages/workflow/lib/auth/k8s-token.ts
+++ b/packages/workflow/lib/auth/k8s-token.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from 'node:fs'
+import { request as undiciRequest, Agent } from 'undici'
+import type pg from 'pg'
+
+interface K8sConfig {
+  apiServer: string
+  caCert?: string
+  adminServiceAccount?: string
+}
+
+export interface K8sValidationResult {
+  applicationId: number | null
+  isAdmin: boolean
+}
+
+interface CacheEntry {
+  applicationId: number | null
+  isAdmin: boolean
+  expiresAt: number
+}
+
+const EXPIRY_BUFFER = 30_000 // 30 seconds before actual expiry
+
+export function createK8sTokenValidator (pool: pg.Pool, config: K8sConfig) {
+  const cache = new Map<string, CacheEntry>()
+
+  let dispatcher: Agent | undefined
+  if (config.caCert) {
+    try {
+      const ca = readFileSync(config.caCert, 'utf-8')
+      dispatcher = new Agent({
+        connect: { ca },
+      })
+    } catch {
+      // CA cert file not available, proceed without custom CA
+    }
+  }
+
+  return async function validateK8sToken (token: string): Promise<K8sValidationResult | null> {
+    // Check cache
+    const cached = cache.get(token)
+    if (cached && cached.expiresAt > Date.now()) {
+      return { applicationId: cached.applicationId, isAdmin: cached.isAdmin }
+    }
+
+    // Call K8s TokenReview API
+    const reviewBody = JSON.stringify({
+      apiVersion: 'authentication.k8s.io/v1',
+      kind: 'TokenReview',
+      spec: { token },
+    })
+
+    const response = await undiciRequest(
+      `${config.apiServer}/apis/authentication.k8s.io/v1/tokenreviews`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: reviewBody,
+        dispatcher,
+      }
+    )
+
+    if (response.statusCode >= 400) {
+      await response.body.dump()
+      return null
+    }
+
+    const review = await response.body.json() as {
+      status: {
+        authenticated: boolean
+        user?: { username: string }
+        error?: string
+      }
+    }
+
+    if (!review.status.authenticated || !review.status.user) return null
+
+    // Parse service account: system:serviceaccount:<namespace>:<name>
+    const parts = review.status.user.username.split(':')
+    if (parts.length !== 4 || parts[0] !== 'system' || parts[1] !== 'serviceaccount') {
+      return null
+    }
+
+    const namespace = parts[2]
+    const serviceAccount = parts[3]
+
+    // Check if this is the admin service account (e.g. ICC)
+    const identity = `${namespace}:${serviceAccount}`
+    const isAdmin = config.adminServiceAccount === identity
+
+    // Look up binding (admin identities may not have one)
+    const result = await pool.query(
+      `SELECT application_id FROM workflow_app_k8s_bindings
+       WHERE namespace = $1 AND service_account = $2`,
+      [namespace, serviceAccount]
+    )
+
+    const applicationId = result.rows.length > 0 ? result.rows[0].application_id : null
+
+    if (applicationId === null && !isAdmin) return null
+
+    // Cache with TTL (use a conservative 5-minute cache for K8s tokens)
+    cache.set(token, {
+      applicationId,
+      isAdmin,
+      expiresAt: Date.now() + 5 * 60 * 1000 - EXPIRY_BUFFER,
+    })
+
+    return { applicationId, isAdmin }
+  }
+}

--- a/packages/workflow/lib/db.ts
+++ b/packages/workflow/lib/db.ts
@@ -1,0 +1,45 @@
+import pg from 'pg'
+import Postgrator from 'postgrator'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { FastifyInstance } from 'fastify'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export interface DbConfig {
+  connectionString: string
+}
+
+export async function initDb (config: DbConfig): Promise<pg.Pool> {
+  const pool = new pg.Pool({ connectionString: config.connectionString })
+
+  // Run migrations
+  const client = await pool.connect()
+  try {
+    const postgrator = new Postgrator({
+      migrationPattern: join(__dirname, '..', 'migrations', '*.sql'),
+      driver: 'pg',
+      execQuery: (query: string) => client.query(query),
+    })
+    await postgrator.migrate()
+  } finally {
+    client.release()
+  }
+
+  return pool
+}
+
+export function decorateDb (app: FastifyInstance, pool: pg.Pool, connectionString: string): void {
+  app.decorate('pg', pool)
+  app.decorate('pgConnectionString', connectionString)
+  app.addHook('onClose', async () => {
+    await pool.end()
+  })
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    pg: pg.Pool
+    pgConnectionString: string
+  }
+}

--- a/packages/workflow/lib/errors.ts
+++ b/packages/workflow/lib/errors.ts
@@ -1,0 +1,15 @@
+import createError from '@fastify/error'
+
+export const RunNotFound = createError('WF_RUN_NOT_FOUND', 'Run %s not found', 404)
+export const StepNotFound = createError('WF_STEP_NOT_FOUND', 'Step %s not found', 404)
+export const HookNotFound = createError('WF_HOOK_NOT_FOUND', 'Hook %s not found', 404)
+export const WaitNotFound = createError('WF_WAIT_NOT_FOUND', 'Wait %s not found', 404)
+export const HookTokenConflict = createError('WF_HOOK_TOKEN_CONFLICT', 'Hook token %s already exists', 409)
+export const DuplicateIdempotencyKey = createError('WF_DUPLICATE_IDEMPOTENCY_KEY', 'Idempotency key %s already processed', 409)
+export const NoHandlerForVersion = createError('WF_NO_HANDLER', 'No handler registered for version %s', 503)
+export const VersionExpired = createError('WF_VERSION_EXPIRED', 'Deployment version %s is expired', 410)
+export const Unauthorized = createError('WF_UNAUTHORIZED', 'Unauthorized: %s', 401)
+export const Forbidden = createError('WF_FORBIDDEN', 'Forbidden: %s', 403)
+export const AppNotFound = createError('WF_APP_NOT_FOUND', 'Application %s not found', 404)
+export const StreamNotFound = createError('WF_STREAM_NOT_FOUND', 'Stream %s not found', 404)
+export const BadRequest = createError('WF_BAD_REQUEST', '%s', 400)

--- a/packages/workflow/lib/quotas.ts
+++ b/packages/workflow/lib/quotas.ts
@@ -1,0 +1,88 @@
+import type { FastifyInstance } from 'fastify'
+
+interface QuotaCache {
+  maxRuns: number
+  maxEventsPerRun: number
+  maxQueuePerMinute: number
+  fetchedAt: number
+}
+
+const CACHE_TTL = 60_000 // 1 minute
+const quotaCache = new Map<number, QuotaCache>()
+const queueCounters = new Map<string, { count: number; resetAt: number }>()
+
+const DEFAULT_QUOTAS = {
+  maxRuns: 10_000,
+  maxEventsPerRun: 100_000,
+  maxQueuePerMinute: 100_000,
+}
+
+async function getQuotas (app: FastifyInstance, appId: number): Promise<QuotaCache> {
+  const cached = quotaCache.get(appId)
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL) return cached
+
+  const result = await app.pg.query(
+    'SELECT max_runs, max_events_per_run, max_queue_per_minute FROM workflow_app_quotas WHERE application_id = $1',
+    [appId]
+  )
+
+  const quotas: QuotaCache = {
+    maxRuns: result.rows.length > 0 ? result.rows[0].max_runs : DEFAULT_QUOTAS.maxRuns,
+    maxEventsPerRun: result.rows.length > 0 ? result.rows[0].max_events_per_run : DEFAULT_QUOTAS.maxEventsPerRun,
+    maxQueuePerMinute: result.rows.length > 0 ? result.rows[0].max_queue_per_minute : DEFAULT_QUOTAS.maxQueuePerMinute,
+    fetchedAt: Date.now(),
+  }
+
+  quotaCache.set(appId, quotas)
+  return quotas
+}
+
+export async function checkRunQuota (app: FastifyInstance, appId: number): Promise<void> {
+  const quotas = await getQuotas(app, appId)
+
+  const result = await app.pg.query(
+    "SELECT COUNT(*)::int as count FROM workflow_runs WHERE application_id = $1 AND status IN ('pending', 'running')",
+    [appId]
+  )
+
+  if (result.rows[0].count >= quotas.maxRuns) {
+    const err = new Error('Run quota exceeded') as any
+    err.statusCode = 429
+    throw err
+  }
+}
+
+export async function checkEventQuota (app: FastifyInstance, appId: number, runId: string): Promise<void> {
+  const quotas = await getQuotas(app, appId)
+
+  const result = await app.pg.query(
+    'SELECT COUNT(*)::int as count FROM workflow_events WHERE application_id = $1 AND run_id = $2',
+    [appId, runId]
+  )
+
+  if (result.rows[0].count >= quotas.maxEventsPerRun) {
+    const err = new Error('Event quota exceeded for this run') as any
+    err.statusCode = 429
+    throw err
+  }
+}
+
+export async function checkQueueRateLimit (app: FastifyInstance, appId: number): Promise<void> {
+  const quotas = await getQuotas(app, appId)
+  const key = `queue_${appId}`
+  const now = Date.now()
+
+  let counter = queueCounters.get(key)
+  if (!counter || now >= counter.resetAt) {
+    counter = { count: 0, resetAt: now + 60_000 }
+    queueCounters.set(key, counter)
+  }
+
+  counter.count++
+
+  if (counter.count > quotas.maxQueuePerMinute) {
+    const err = new Error('Queue rate limit exceeded') as any
+    err.statusCode = 429
+    throw err
+  }
+}

--- a/packages/workflow/migrations/001.do.sql
+++ b/packages/workflow/migrations/001.do.sql
@@ -1,0 +1,204 @@
+-- Platformatic Workflow Service Schema
+-- Single migration: auth + core + queue + encryption + deployment versions
+
+-- ============================================================
+-- Auth tables
+-- ============================================================
+
+CREATE TABLE workflow_applications (
+  id              SERIAL PRIMARY KEY,
+  app_id          VARCHAR NOT NULL UNIQUE,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE workflow_app_k8s_bindings (
+  id              SERIAL PRIMARY KEY,
+  application_id  INTEGER NOT NULL REFERENCES workflow_applications(id),
+  namespace       VARCHAR NOT NULL,
+  service_account VARCHAR NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (namespace, service_account)
+);
+
+-- ============================================================
+-- Core workflow tables
+-- ============================================================
+
+CREATE TABLE workflow_runs (
+  id              VARCHAR PRIMARY KEY,
+  application_id  INTEGER NOT NULL REFERENCES workflow_applications(id),
+  workflow_name   VARCHAR NOT NULL,
+  deployment_id   VARCHAR NOT NULL,
+  status          VARCHAR NOT NULL DEFAULT 'pending',
+  input           BYTEA,
+  output          BYTEA,
+  error           JSONB,
+  execution_context JSONB,
+  spec_version    INTEGER,
+  started_at      TIMESTAMPTZ,
+  completed_at    TIMESTAMPTZ,
+  expired_at      TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_wr_app_status ON workflow_runs (application_id, status);
+CREATE INDEX idx_wr_app_deployment ON workflow_runs (application_id, deployment_id);
+
+CREATE TABLE workflow_events (
+  id              SERIAL PRIMARY KEY,
+  run_id          VARCHAR NOT NULL REFERENCES workflow_runs(id),
+  application_id  INTEGER NOT NULL,
+  event_type      VARCHAR NOT NULL,
+  correlation_id  VARCHAR,
+  event_data      BYTEA,
+  spec_version    INTEGER,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_we_run_id ON workflow_events (run_id, id ASC);
+CREATE INDEX idx_we_correlation ON workflow_events (application_id, correlation_id) WHERE correlation_id IS NOT NULL;
+
+CREATE TABLE workflow_steps (
+  id              VARCHAR PRIMARY KEY,
+  run_id          VARCHAR NOT NULL REFERENCES workflow_runs(id),
+  application_id  INTEGER NOT NULL,
+  correlation_id  VARCHAR NOT NULL,
+  step_name       VARCHAR NOT NULL,
+  status          VARCHAR NOT NULL DEFAULT 'pending',
+  input           BYTEA,
+  output          BYTEA,
+  error           JSONB,
+  attempt         INTEGER NOT NULL DEFAULT 1,
+  retry_after     TIMESTAMPTZ,
+  spec_version    INTEGER,
+  started_at      TIMESTAMPTZ,
+  completed_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_ws_run_id ON workflow_steps (run_id);
+
+CREATE TABLE workflow_hooks (
+  id              VARCHAR PRIMARY KEY,
+  run_id          VARCHAR NOT NULL REFERENCES workflow_runs(id),
+  application_id  INTEGER NOT NULL,
+  correlation_id  VARCHAR NOT NULL,
+  token           VARCHAR NOT NULL,
+  owner_id        VARCHAR NOT NULL DEFAULT '',
+  project_id      VARCHAR NOT NULL DEFAULT '',
+  environment     VARCHAR NOT NULL DEFAULT '',
+  metadata        BYTEA,
+  status          VARCHAR NOT NULL DEFAULT 'pending',
+  is_webhook      BOOLEAN NOT NULL DEFAULT false,
+  received_at     TIMESTAMPTZ,
+  disposed_at     TIMESTAMPTZ,
+  spec_version    INTEGER,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_wh_token_active ON workflow_hooks (token) WHERE status = 'pending';
+CREATE INDEX idx_wh_token ON workflow_hooks (token);
+CREATE INDEX idx_wh_run_id ON workflow_hooks (run_id);
+CREATE INDEX idx_wh_status ON workflow_hooks (application_id, status);
+
+CREATE TABLE workflow_waits (
+  id              VARCHAR PRIMARY KEY,
+  run_id          VARCHAR NOT NULL REFERENCES workflow_runs(id),
+  application_id  INTEGER NOT NULL,
+  correlation_id  VARCHAR NOT NULL,
+  status          VARCHAR NOT NULL DEFAULT 'waiting',
+  resume_at       TIMESTAMPTZ,
+  spec_version    INTEGER,
+  completed_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_ww_run_id ON workflow_waits (run_id);
+
+CREATE TABLE workflow_stream_chunks (
+  id              SERIAL PRIMARY KEY,
+  stream_name     VARCHAR NOT NULL,
+  run_id          VARCHAR NOT NULL REFERENCES workflow_runs(id),
+  application_id  INTEGER NOT NULL,
+  chunk_index     INTEGER NOT NULL,
+  data            BYTEA NOT NULL,
+  is_closed       BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_wsc_stream ON workflow_stream_chunks (application_id, stream_name, chunk_index ASC);
+CREATE INDEX idx_wsc_run ON workflow_stream_chunks (run_id);
+
+-- ============================================================
+-- Queue tables
+-- ============================================================
+
+CREATE TABLE workflow_queue_handlers (
+  id              SERIAL PRIMARY KEY,
+  deployment_version VARCHAR NOT NULL,
+  application_id  INTEGER NOT NULL,
+  pod_id          VARCHAR NOT NULL,
+  workflow_url    VARCHAR NOT NULL,
+  step_url        VARCHAR NOT NULL,
+  webhook_url     VARCHAR NOT NULL,
+  registered_at   TIMESTAMPTZ DEFAULT NOW(),
+  last_heartbeat  TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (application_id, pod_id)
+);
+
+CREATE TABLE workflow_queue_messages (
+  id              SERIAL PRIMARY KEY,
+  idempotency_key VARCHAR,
+  queue_name      VARCHAR NOT NULL,
+  run_id          VARCHAR NOT NULL,
+  deployment_version VARCHAR NOT NULL,
+  application_id  INTEGER NOT NULL,
+  payload         JSONB NOT NULL,
+  status          VARCHAR DEFAULT 'pending',
+  attempts        INTEGER DEFAULT 0,
+  deliver_at      TIMESTAMPTZ,
+  next_retry_at   TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  delivered_at    TIMESTAMPTZ,
+  UNIQUE (idempotency_key)
+);
+
+CREATE INDEX idx_wqm_deferred ON workflow_queue_messages (deliver_at)
+  WHERE status = 'deferred';
+CREATE INDEX idx_wqm_status_retry ON workflow_queue_messages (status, next_retry_at)
+  WHERE status = 'failed';
+CREATE INDEX idx_wqm_pending ON workflow_queue_messages (created_at)
+  WHERE status = 'pending';
+CREATE INDEX idx_wqm_run_id ON workflow_queue_messages (run_id);
+
+-- ============================================================
+-- Support tables
+-- ============================================================
+
+CREATE TABLE workflow_encryption_keys (
+  application_id  INTEGER NOT NULL PRIMARY KEY REFERENCES workflow_applications(id),
+  secret          BYTEA NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE workflow_deployment_versions (
+  id              SERIAL PRIMARY KEY,
+  application_id  INTEGER NOT NULL REFERENCES workflow_applications(id),
+  deployment_version VARCHAR NOT NULL,
+  status          VARCHAR NOT NULL DEFAULT 'active',
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (application_id, deployment_version)
+);
+
+CREATE TABLE workflow_app_quotas (
+  application_id  INTEGER NOT NULL PRIMARY KEY REFERENCES workflow_applications(id),
+  max_runs        INTEGER NOT NULL DEFAULT 10000,
+  max_events_per_run INTEGER NOT NULL DEFAULT 10000,
+  max_queue_per_minute INTEGER NOT NULL DEFAULT 1000,
+  created_at      TIMESTAMPTZ DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -7,16 +7,22 @@
     "node": ">=22.19.0"
   },
   "scripts": {
-    "start": "node src/server.ts",
+    "start": "wattpm start",
+    "dev": "wattpm dev",
     "test": "node --test --test-concurrency=1 test/*.test.ts",
     "lint": "eslint"
   },
   "dependencies": {
+    "@fastify/autoload": "^6.0.3",
     "@fastify/error": "^4.1.0",
+    "@platformatic/leader": "^0.1.0",
+    "@platformatic/service": "^3.40.0",
     "fastify": "^5.3.3",
+    "fastify-plugin": "^5.1.0",
     "pg": "^8.16.0",
     "postgrator": "^8.0.0",
-    "undici": "^7.22.0"
+    "undici": "^7.22.0",
+    "wattpm": "^3.40.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.0",

--- a/packages/workflow/plugins/apps.ts
+++ b/packages/workflow/plugins/apps.ts
@@ -1,0 +1,80 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { AppNotFound, Forbidden, BadRequest } from '../lib/errors.ts'
+
+async function appsPlugin (app: FastifyInstance): Promise<void> {
+  // Create application
+  app.post('/api/v1/apps', async (request, reply) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const { appId } = request.body as { appId: string }
+    if (!appId) throw new BadRequest('appId is required')
+
+    try {
+      await app.pg.query(
+        'INSERT INTO workflow_applications (app_id) VALUES ($1)',
+        [appId]
+      )
+
+      reply.code(201)
+      return { appId }
+    } catch (err: any) {
+      if (err.code === '23505') {
+        throw new BadRequest(`application ${appId} already exists`)
+      }
+      throw err
+    }
+  })
+
+  // Create K8s binding
+  app.post('/api/v1/apps/:appId/k8s-binding', async (request, reply) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const { appId } = request.params as { appId: string }
+    const { namespace, serviceAccount } = request.body as { namespace: string; serviceAccount: string }
+
+    if (!namespace || !serviceAccount) {
+      throw new BadRequest('namespace and serviceAccount are required')
+    }
+
+    const appResult = await app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1',
+      [appId]
+    )
+    if (appResult.rows.length === 0) throw new AppNotFound(appId)
+
+    await app.pg.query(
+      `INSERT INTO workflow_app_k8s_bindings (application_id, namespace, service_account)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (namespace, service_account) DO UPDATE SET application_id = $1`,
+      [appResult.rows[0].id, namespace, serviceAccount]
+    )
+
+    reply.code(201)
+    return { appId, namespace, serviceAccount }
+  })
+
+  // Delete K8s binding
+  app.delete('/api/v1/apps/:appId/k8s-binding', async (request) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const { appId } = request.params as { appId: string }
+    const { namespace, serviceAccount } = request.body as { namespace: string; serviceAccount: string }
+
+    const appResult = await app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1',
+      [appId]
+    )
+    if (appResult.rows.length === 0) throw new AppNotFound(appId)
+
+    await app.pg.query(
+      `DELETE FROM workflow_app_k8s_bindings
+       WHERE application_id = $1 AND namespace = $2 AND service_account = $3`,
+      [appResult.rows[0].id, namespace, serviceAccount]
+    )
+
+    return { deleted: true }
+  })
+}
+
+export default fp(appsPlugin, { name: 'apps', dependencies: ['auth'] })

--- a/packages/workflow/plugins/auth.ts
+++ b/packages/workflow/plugins/auth.ts
@@ -1,0 +1,9 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import authPlugin from '../lib/auth/index.ts'
+
+async function authWrapper (app: FastifyInstance): Promise<void> {
+  await app.register(authPlugin, app.authConfig)
+}
+
+export default fp(authWrapper, { name: 'auth', dependencies: ['db'] })

--- a/packages/workflow/plugins/db.ts
+++ b/packages/workflow/plugins/db.ts
@@ -1,0 +1,53 @@
+import fp from 'fastify-plugin'
+import { existsSync } from 'node:fs'
+import type { FastifyInstance } from 'fastify'
+import { initDb, decorateDb } from '../lib/db.ts'
+import type { AuthConfig } from '../lib/auth/index.ts'
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    authConfig: AuthConfig
+  }
+}
+
+async function dbPlugin (app: FastifyInstance): Promise<void> {
+  const connectionString = process.env.DATABASE_URL || 'postgresql://wf:wf@localhost:5434/workflow'
+
+  const pool = await initDb({ connectionString })
+  decorateDb(app, pool, connectionString)
+
+  // Detect mode and build auth config
+  const isK8s = existsSync('/var/run/secrets/kubernetes.io/serviceaccount/token')
+
+  let authConfig: AuthConfig
+
+  if (isK8s) {
+    const authMode = (process.env.WF_AUTH_MODE || 'k8s-token') as 'api-key' | 'k8s-token' | 'both'
+    authConfig = {
+      mode: authMode,
+      k8s: authMode !== 'api-key'
+        ? {
+            apiServer: process.env.K8S_API_SERVER || 'https://kubernetes.default.svc',
+            caCert: process.env.K8S_CA_CERT || '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+            adminServiceAccount: process.env.K8S_ADMIN_SERVICE_ACCOUNT,
+          }
+        : undefined,
+    }
+    app.log.info('Starting in multi-tenant mode (K8s detected)')
+  } else {
+    const appIdStr = process.env.PLT_WORLD_APP_ID || 'default'
+    const result = await pool.query(
+      `INSERT INTO workflow_applications (app_id)
+       VALUES ($1)
+       ON CONFLICT (app_id) DO UPDATE SET app_id = $1
+       RETURNING id`,
+      [appIdStr]
+    )
+    authConfig = { mode: 'none', defaultAppId: result.rows[0].id }
+    app.log.info('Starting in single-tenant mode (no K8s detected)')
+  }
+
+  app.decorate('authConfig', authConfig)
+}
+
+export default fp(dbPlugin, { name: 'db' })

--- a/packages/workflow/plugins/dead-letters.ts
+++ b/packages/workflow/plugins/dead-letters.ts
@@ -1,0 +1,74 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { BadRequest } from '../lib/errors.ts'
+
+async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
+  // List dead-lettered messages
+  app.get('/api/v1/apps/:appId/dead-letters', async (request) => {
+    const appId = request.appId
+    const query = request.query as { limit?: string; cursor?: string; queueName?: string }
+    const limit = Math.min(parseInt(query.limit || '50', 10), 200)
+    const offset = query.cursor ? parseInt(query.cursor, 10) : 0
+
+    const conditions = ['application_id = $1', "status = 'dead'"]
+    const params: any[] = [appId]
+    let paramIdx = 2
+
+    if (query.queueName) {
+      conditions.push(`queue_name = $${paramIdx++}`)
+      params.push(query.queueName)
+    }
+
+    params.push(limit + 1)
+    params.push(offset)
+
+    const result = await app.pg.query(
+      `SELECT id, idempotency_key, queue_name, run_id, deployment_version, payload, attempts, created_at
+       FROM workflow_queue_messages
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY created_at DESC
+       LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+      params
+    )
+
+    const hasMore = result.rows.length > limit
+    const data = result.rows.slice(0, limit).map(row => ({
+      messageId: `msg_${row.id}`,
+      idempotencyKey: row.idempotency_key,
+      queueName: row.queue_name,
+      runId: row.run_id,
+      deploymentVersion: row.deployment_version,
+      payload: row.payload,
+      attempts: row.attempts,
+      createdAt: row.created_at,
+    }))
+    const nextCursor = hasMore ? String(offset + limit) : null
+
+    return { data, cursor: nextCursor, hasMore }
+  })
+
+  // Retry a dead-lettered message
+  app.post('/api/v1/apps/:appId/dead-letters/:messageId/retry', async (request) => {
+    const appId = request.appId
+    const { messageId } = request.params as { messageId: string }
+    const numericId = parseInt(messageId.replace('msg_', ''), 10)
+
+    if (isNaN(numericId)) throw new BadRequest('invalid messageId')
+
+    const result = await app.pg.query(
+      `UPDATE workflow_queue_messages
+       SET status = 'pending', attempts = 0, next_retry_at = NULL
+       WHERE id = $1 AND application_id = $2 AND status = 'dead'
+       RETURNING id`,
+      [numericId, appId]
+    )
+
+    if (result.rows.length === 0) {
+      throw new BadRequest('message not found or not in dead state')
+    }
+
+    return { retried: true, messageId: `msg_${numericId}` }
+  })
+}
+
+export default fp(deadLettersPlugin, { name: 'dead-letters', dependencies: ['auth'] })

--- a/packages/workflow/plugins/draining.ts
+++ b/packages/workflow/plugins/draining.ts
@@ -1,0 +1,122 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { Forbidden } from '../lib/errors.ts'
+
+async function drainingPlugin (app: FastifyInstance): Promise<void> {
+  // Get version status — called by ICC
+  app.get('/api/v1/apps/:appId/versions/:deploymentId/status', async (request) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const { deploymentId } = request.params as { deploymentId: string }
+    const appId = request.appId
+
+    const [runs, hooks, waits, messages] = await Promise.all([
+      app.pg.query(
+        `SELECT COUNT(*)::int as count FROM workflow_runs
+         WHERE application_id = $1 AND deployment_id = $2 AND status IN ('pending', 'running')`,
+        [appId, deploymentId]
+      ),
+      app.pg.query(
+        `SELECT COUNT(*)::int as count FROM workflow_hooks h
+         JOIN workflow_runs r ON h.run_id = r.id
+         WHERE h.application_id = $1 AND r.deployment_id = $2 AND h.status NOT IN ('disposed')`,
+        [appId, deploymentId]
+      ),
+      app.pg.query(
+        `SELECT COUNT(*)::int as count FROM workflow_waits w
+         JOIN workflow_runs r ON w.run_id = r.id
+         WHERE w.application_id = $1 AND r.deployment_id = $2 AND w.status = 'waiting'`,
+        [appId, deploymentId]
+      ),
+      app.pg.query(
+        `SELECT COUNT(*)::int as count FROM workflow_queue_messages
+         WHERE application_id = $1 AND deployment_version = $2 AND status IN ('pending', 'deferred', 'failed')`,
+        [appId, deploymentId]
+      ),
+    ])
+
+    return {
+      activeRuns: runs.rows[0].count,
+      pendingHooks: hooks.rows[0].count,
+      pendingWaits: waits.rows[0].count,
+      queuedMessages: messages.rows[0].count,
+    }
+  })
+
+  // Force-expire a deployment version — called by ICC
+  app.post('/api/v1/apps/:appId/versions/:deploymentId/expire', async (request) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const { deploymentId } = request.params as { deploymentId: string }
+    const appId = request.appId
+
+    const client = await app.pg.connect()
+    try {
+      await client.query('BEGIN')
+
+      // 1. Cancel all in-flight runs
+      const cancelledRuns = await client.query(
+        `UPDATE workflow_runs SET status = 'cancelled', completed_at = NOW(), updated_at = NOW()
+         WHERE application_id = $1 AND deployment_id = $2 AND status IN ('pending', 'running')
+         RETURNING id`,
+        [appId, deploymentId]
+      )
+
+      // 2. Create run_cancelled events
+      for (const row of cancelledRuns.rows) {
+        await client.query(
+          `INSERT INTO workflow_events (run_id, application_id, event_type, event_data)
+           VALUES ($1, $2, 'run_cancelled', NULL)`,
+          [row.id, appId]
+        )
+      }
+
+      // 3. Dispose hooks for the cancelled runs only
+      if (cancelledRuns.rows.length > 0) {
+        const runIds = cancelledRuns.rows.map(r => r.id)
+        await client.query(
+          `UPDATE workflow_hooks SET status = 'disposed', disposed_at = NOW()
+           WHERE application_id = $1 AND run_id = ANY($2::varchar[]) AND status != 'disposed'`,
+          [appId, runIds]
+        )
+      }
+
+      // 4. Dead-letter queued messages
+      const deadLettered = await client.query(
+        `UPDATE workflow_queue_messages SET status = 'dead'
+         WHERE application_id = $1 AND deployment_version = $2
+           AND status IN ('pending', 'deferred', 'failed')
+         RETURNING id`,
+        [appId, deploymentId]
+      )
+
+      // 5. Deregister handlers
+      await client.query(
+        `DELETE FROM workflow_queue_handlers
+         WHERE application_id = $1 AND deployment_version = $2`,
+        [appId, deploymentId]
+      )
+
+      // 6. Update version status
+      await client.query(
+        `UPDATE workflow_deployment_versions SET status = 'expired', updated_at = NOW()
+         WHERE application_id = $1 AND deployment_version = $2`,
+        [appId, deploymentId]
+      )
+
+      await client.query('COMMIT')
+
+      return {
+        cancelledRuns: cancelledRuns.rows.length,
+        deadLetteredMessages: deadLettered.rows.length,
+      }
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    } finally {
+      client.release()
+    }
+  })
+}
+
+export default fp(drainingPlugin, { name: 'draining', dependencies: ['auth'] })

--- a/packages/workflow/plugins/encryption.ts
+++ b/packages/workflow/plugins/encryption.ts
@@ -1,0 +1,38 @@
+import fp from 'fastify-plugin'
+import { hkdfSync } from 'node:crypto'
+import type { FastifyInstance } from 'fastify'
+import { BadRequest } from '../lib/errors.ts'
+
+async function encryptionPlugin (app: FastifyInstance): Promise<void> {
+  app.get('/api/v1/apps/:appId/encryption-key', async (request) => {
+    const query = request.query as { runId?: string }
+    const appId = request.appId
+
+    if (!query.runId) throw new BadRequest('runId is required')
+
+    // Only return a key if one was explicitly provisioned for this app
+    const secretRow = await app.pg.query(
+      'SELECT secret FROM workflow_encryption_keys WHERE application_id = $1',
+      [appId]
+    )
+
+    if (secretRow.rows.length === 0) {
+      return { key: null }
+    }
+
+    const secret = secretRow.rows[0].secret
+
+    // Derive per-run key via HKDF
+    const derivedKey = hkdfSync(
+      'sha256',
+      secret,
+      query.runId, // salt
+      'workflow-encryption', // info
+      32 // 256-bit key
+    )
+
+    return { key: Buffer.from(derivedKey).toString('base64') }
+  })
+}
+
+export default fp(encryptionPlugin, { name: 'encryption', dependencies: ['auth'] })

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -1,0 +1,602 @@
+import fp from 'fastify-plugin'
+import { randomUUID } from 'node:crypto'
+import type { FastifyInstance } from 'fastify'
+import { RunNotFound, BadRequest } from '../lib/errors.ts'
+import { checkRunQuota, checkEventQuota } from '../lib/quotas.ts'
+import type pg from 'pg'
+
+// Encode data as binary for storage. Supports both Uint8Array (base64) and JSON.
+function encodeData (data: unknown): Buffer | null {
+  if (data === undefined || data === null) return null
+  if (data instanceof Uint8Array || Buffer.isBuffer(data)) return Buffer.from(data)
+  // If it's a base64-encoded string representing binary, decode it
+  if (typeof data === 'string') {
+    try {
+      return Buffer.from(data, 'base64')
+    } catch {
+      return Buffer.from(JSON.stringify(data))
+    }
+  }
+  return Buffer.from(JSON.stringify(data))
+}
+
+function decodeData (buf: Buffer | null): unknown {
+  if (buf === null) return undefined
+  // Try to detect if it's JSON
+  if (buf[0] === 0x7b || buf[0] === 0x5b || buf[0] === 0x22) {
+    try {
+      return JSON.parse(buf.toString('utf-8'))
+    } catch {
+      // Not JSON, return as base64
+    }
+  }
+  return buf.toString('base64')
+}
+
+function formatEvent (row: any, resolveData?: string) {
+  const event: any = {
+    eventId: String(row.id),
+    runId: row.run_id,
+    eventType: row.event_type,
+    createdAt: row.created_at,
+    specVersion: row.spec_version,
+  }
+  if (row.correlation_id) event.correlationId = row.correlation_id
+  if (resolveData !== 'none' && row.event_data) {
+    event.eventData = decodeData(row.event_data)
+  }
+  return event
+}
+
+function formatRun (row: any, resolveData?: string) {
+  const run: any = {
+    runId: row.id,
+    status: row.status,
+    deploymentId: row.deployment_id,
+    workflowName: row.workflow_name,
+    specVersion: row.spec_version,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+  if (resolveData !== 'none') {
+    run.input = decodeData(row.input)
+    run.output = decodeData(row.output)
+  } else {
+    run.input = undefined
+    run.output = undefined
+  }
+  if (row.error) run.error = row.error
+  if (row.execution_context) run.executionContext = row.execution_context
+  if (row.started_at) run.startedAt = row.started_at
+  if (row.completed_at) run.completedAt = row.completed_at
+  if (row.expired_at) run.expiredAt = row.expired_at
+  return run
+}
+
+function formatStep (row: any, resolveData?: string) {
+  const step: any = {
+    runId: row.run_id,
+    stepId: row.id,
+    stepName: row.step_name,
+    status: row.status,
+    attempt: row.attempt,
+    specVersion: row.spec_version,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+  if (resolveData !== 'none') {
+    step.input = decodeData(row.input)
+    step.output = decodeData(row.output)
+  } else {
+    step.input = undefined
+    step.output = undefined
+  }
+  if (row.error) step.error = row.error
+  if (row.started_at) step.startedAt = row.started_at
+  if (row.completed_at) step.completedAt = row.completed_at
+  if (row.retry_after) step.retryAfter = row.retry_after
+  return step
+}
+
+function formatHook (row: any) {
+  const hook: any = {
+    runId: row.run_id,
+    hookId: row.correlation_id,
+    token: row.token,
+    status: row.status,
+    ownerId: row.owner_id,
+    projectId: row.project_id,
+    environment: row.environment,
+    metadata: decodeData(row.metadata),
+    createdAt: row.created_at,
+    specVersion: row.spec_version,
+    isWebhook: row.is_webhook ?? false,
+  }
+  if (row.received_at) hook.receivedAt = row.received_at
+  if (row.disposed_at) hook.disposedAt = row.disposed_at
+  return hook
+}
+
+function formatWait (row: any) {
+  return {
+    waitId: row.id,
+    runId: row.run_id,
+    status: row.status,
+    resumeAt: row.resume_at,
+    completedAt: row.completed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    specVersion: row.spec_version,
+  }
+}
+
+async function insertEvent (client: pg.PoolClient, runId: string, appId: number, body: any): Promise<any> {
+  const eventData = body.eventData ? encodeData(body.eventData) : null
+  const result = await client.query(
+    `INSERT INTO workflow_events (run_id, application_id, event_type, correlation_id, event_data, spec_version)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [runId, appId, body.eventType, body.correlationId || null, eventData, body.specVersion || null]
+  )
+  return result.rows[0]
+}
+
+async function eventsPlugin (app: FastifyInstance): Promise<void> {
+  // Custom error handler to include meta in error responses (for SDK compatibility)
+  app.setErrorHandler((error: any, _request, reply) => {
+    const statusCode = error.statusCode || 500
+    const response: any = {
+      statusCode,
+      error: statusCode >= 500 ? 'Internal Server Error' : error.message,
+      message: error.message,
+    }
+    if (error.meta) response.meta = error.meta
+    reply.code(statusCode).send(response)
+  })
+
+  // Create event (main write path)
+  app.post('/api/v1/apps/:appId/runs/:runId/events', async (request) => {
+    const { runId: rawRunId } = request.params as { runId: string }
+    const body = request.body as any
+    const appId = request.appId
+    const resolveData = (request.query as any).resolveData
+
+    // Quota checks
+    if (body.eventType === 'run_created') {
+      await checkRunQuota(app, appId)
+    } else if (rawRunId !== 'null') {
+      await checkEventQuota(app, appId, rawRunId)
+    }
+
+    const client = await app.pg.connect()
+    try {
+      await client.query('BEGIN')
+
+      let result: any
+
+      switch (body.eventType) {
+        case 'run_created': {
+          const runId = rawRunId === 'null' ? randomUUID() : rawRunId
+          const eventData = body.eventData || {}
+          const input = encodeData(eventData.input)
+
+          await client.query(
+            `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, input, execution_context, spec_version)
+             VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7)`,
+            [runId, appId, eventData.workflowName, eventData.deploymentId, input, eventData.executionContext || null, body.specVersion || null]
+          )
+
+          const eventRow = await insertEvent(client, runId, appId, body)
+          const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [runId])).rows[0]
+
+          result = { event: formatEvent(eventRow, resolveData), run: formatRun(runRow, resolveData) }
+          break
+        }
+
+        case 'run_started': {
+          await client.query(
+            `UPDATE workflow_runs SET status = 'running', started_at = NOW(), updated_at = NOW()
+             WHERE id = $1 AND application_id = $2`,
+            [rawRunId, appId]
+          )
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [rawRunId])).rows[0]
+          if (!runRow) throw new RunNotFound(rawRunId)
+          result = { event: formatEvent(eventRow, resolveData), run: formatRun(runRow, resolveData) }
+          break
+        }
+
+        case 'run_completed': {
+          const output = body.eventData?.output ? encodeData(body.eventData.output) : null
+          await client.query(
+            `UPDATE workflow_runs SET status = 'completed', output = $3, completed_at = NOW(), updated_at = NOW()
+             WHERE id = $1 AND application_id = $2`,
+            [rawRunId, appId, output]
+          )
+          // Clean up all hooks and waits for this run
+          await client.query(
+            'UPDATE workflow_hooks SET status = \'disposed\', disposed_at = NOW() WHERE run_id = $1 AND application_id = $2 AND status != \'disposed\'',
+            [rawRunId, appId]
+          )
+          await client.query(
+            'UPDATE workflow_waits SET status = \'completed\', completed_at = NOW(), updated_at = NOW() WHERE run_id = $1 AND application_id = $2 AND status = \'waiting\'',
+            [rawRunId, appId]
+          )
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [rawRunId])).rows[0]
+          if (!runRow) throw new RunNotFound(rawRunId)
+          result = { event: formatEvent(eventRow, resolveData), run: formatRun(runRow, resolveData) }
+          break
+        }
+
+        case 'run_failed': {
+          const rawError = body.eventData?.error
+          const error = rawError
+            ? {
+                message: typeof rawError === 'string' ? rawError : (rawError.message || JSON.stringify(rawError)),
+                code: body.eventData.errorCode,
+              }
+            : null
+          await client.query(
+            `UPDATE workflow_runs SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
+             WHERE id = $1 AND application_id = $2`,
+            [rawRunId, appId, error ? JSON.stringify(error) : null]
+          )
+          await client.query(
+            'UPDATE workflow_hooks SET status = \'disposed\', disposed_at = NOW() WHERE run_id = $1 AND application_id = $2 AND status != \'disposed\'',
+            [rawRunId, appId]
+          )
+          await client.query(
+            'UPDATE workflow_waits SET status = \'completed\', completed_at = NOW(), updated_at = NOW() WHERE run_id = $1 AND application_id = $2 AND status = \'waiting\'',
+            [rawRunId, appId]
+          )
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [rawRunId])).rows[0]
+          if (!runRow) throw new RunNotFound(rawRunId)
+          result = { event: formatEvent(eventRow, resolveData), run: formatRun(runRow, resolveData) }
+          break
+        }
+
+        case 'run_cancelled': {
+          await client.query(
+            `UPDATE workflow_runs SET status = 'cancelled', completed_at = NOW(), updated_at = NOW()
+             WHERE id = $1 AND application_id = $2`,
+            [rawRunId, appId]
+          )
+          await client.query(
+            'UPDATE workflow_hooks SET status = \'disposed\', disposed_at = NOW() WHERE run_id = $1 AND application_id = $2 AND status != \'disposed\'',
+            [rawRunId, appId]
+          )
+          await client.query(
+            'UPDATE workflow_waits SET status = \'completed\', completed_at = NOW(), updated_at = NOW() WHERE run_id = $1 AND application_id = $2 AND status = \'waiting\'',
+            [rawRunId, appId]
+          )
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [rawRunId])).rows[0]
+          if (!runRow) throw new RunNotFound(rawRunId)
+          result = { event: formatEvent(eventRow, resolveData), run: formatRun(runRow, resolveData) }
+          break
+        }
+
+        case 'run_expired': {
+          await client.query(
+            `UPDATE workflow_runs SET status = 'expired', expired_at = NOW(), completed_at = NOW(), updated_at = NOW()
+             WHERE id = $1 AND application_id = $2`,
+            [rawRunId, appId]
+          )
+          await client.query(
+            'UPDATE workflow_hooks SET status = \'disposed\', disposed_at = NOW() WHERE run_id = $1 AND application_id = $2 AND status != \'disposed\'',
+            [rawRunId, appId]
+          )
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [rawRunId])).rows[0]
+          if (!runRow) throw new RunNotFound(rawRunId)
+          result = { event: formatEvent(eventRow, resolveData), run: formatRun(runRow, resolveData) }
+          break
+        }
+
+        case 'step_created': {
+          const stepId = randomUUID()
+          const eventData = body.eventData || {}
+          const input = encodeData(eventData.input)
+
+          await client.query(
+            `INSERT INTO workflow_steps (id, run_id, application_id, correlation_id, step_name, status, input, spec_version)
+             VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7)`,
+            [stepId, rawRunId, appId, body.correlationId, eventData.stepName, input, body.specVersion || null]
+          )
+
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const stepRow = (await client.query('SELECT * FROM workflow_steps WHERE id = $1', [stepId])).rows[0]
+          result = { event: formatEvent(eventRow, resolveData), step: formatStep(stepRow, resolveData) }
+          break
+        }
+
+        case 'step_started': {
+          // Find step by correlation_id + run_id
+          const stepResult = await client.query(
+            'SELECT * FROM workflow_steps WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3',
+            [rawRunId, body.correlationId, appId]
+          )
+
+          if (stepResult.rows.length > 0) {
+            const step = stepResult.rows[0]
+
+            // Check if step is in a terminal state (completed/cancelled)
+            if (step.status === 'completed' || step.status === 'cancelled') {
+              await client.query('COMMIT')
+              const err: any = new Error(`Step ${body.correlationId} is in terminal state: ${step.status}`)
+              err.statusCode = 409
+              throw err
+            }
+
+            // Check if retry_after timestamp hasn't been reached yet
+            if (step.retry_after && new Date(step.retry_after) > new Date()) {
+              await client.query('COMMIT')
+              const err: any = new Error(`Step ${body.correlationId} retryAfter not reached`)
+              err.statusCode = 425
+              err.meta = { retryAfter: new Date(step.retry_after).toISOString() }
+              throw err
+            }
+
+            // Increment attempt when retrying: after a retry cycle (step_started →
+            // error → step_retrying → step_started), started_at is already set.
+            // We can't rely on retry_after because the SDK only sends retryAfter
+            // for RetryableError — regular errors have retry_after = NULL.
+            const isRetry = step.status === 'pending' && step.started_at !== null
+            const attempt = isRetry ? step.attempt + 1 : (body.eventData?.attempt || step.attempt || 1)
+
+            await client.query(
+              `UPDATE workflow_steps SET status = 'running', attempt = $3, retry_after = NULL, started_at = COALESCE(started_at, NOW()), updated_at = NOW()
+               WHERE id = $1 AND application_id = $2`,
+              [step.id, appId, attempt]
+            )
+          }
+
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const stepRow = stepResult.rows.length > 0
+            ? (await client.query('SELECT * FROM workflow_steps WHERE id = $1', [stepResult.rows[0].id])).rows[0]
+            : null
+          result = { event: formatEvent(eventRow, resolveData), step: stepRow ? formatStep(stepRow, resolveData) : undefined }
+          break
+        }
+
+        case 'step_completed': {
+          const resultData = body.eventData?.result ? encodeData(body.eventData.result) : null
+          const stepResult = await client.query(
+            'SELECT id FROM workflow_steps WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3',
+            [rawRunId, body.correlationId, appId]
+          )
+          if (stepResult.rows.length > 0) {
+            await client.query(
+              `UPDATE workflow_steps SET status = 'completed', output = $3, completed_at = NOW(), updated_at = NOW()
+               WHERE id = $1 AND application_id = $2`,
+              [stepResult.rows[0].id, appId, resultData]
+            )
+          }
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const stepRow = stepResult.rows.length > 0
+            ? (await client.query('SELECT * FROM workflow_steps WHERE id = $1', [stepResult.rows[0].id])).rows[0]
+            : null
+          result = { event: formatEvent(eventRow, resolveData), step: stepRow ? formatStep(stepRow, resolveData) : undefined }
+          break
+        }
+
+        case 'step_failed': {
+          const error = body.eventData
+            ? { message: String(body.eventData.error || ''), stack: body.eventData.stack }
+            : null
+          const stepResult = await client.query(
+            'SELECT id FROM workflow_steps WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3',
+            [rawRunId, body.correlationId, appId]
+          )
+          if (stepResult.rows.length > 0) {
+            await client.query(
+              `UPDATE workflow_steps SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
+               WHERE id = $1 AND application_id = $2`,
+              [stepResult.rows[0].id, appId, error ? JSON.stringify(error) : null]
+            )
+          }
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const stepRow = stepResult.rows.length > 0
+            ? (await client.query('SELECT * FROM workflow_steps WHERE id = $1', [stepResult.rows[0].id])).rows[0]
+            : null
+          result = { event: formatEvent(eventRow, resolveData), step: stepRow ? formatStep(stepRow, resolveData) : undefined }
+          break
+        }
+
+        case 'step_retrying': {
+          const error = body.eventData
+            ? { message: String(body.eventData.error || ''), stack: body.eventData.stack }
+            : null
+          const retryAfter = body.eventData?.retryAfter ? new Date(body.eventData.retryAfter) : null
+          const stepResult = await client.query(
+            'SELECT id FROM workflow_steps WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3',
+            [rawRunId, body.correlationId, appId]
+          )
+          if (stepResult.rows.length > 0) {
+            await client.query(
+              `UPDATE workflow_steps SET status = 'pending', error = $3, retry_after = $4, updated_at = NOW()
+               WHERE id = $1 AND application_id = $2`,
+              [stepResult.rows[0].id, appId, error ? JSON.stringify(error) : null, retryAfter]
+            )
+          }
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const stepRow = stepResult.rows.length > 0
+            ? (await client.query('SELECT * FROM workflow_steps WHERE id = $1', [stepResult.rows[0].id])).rows[0]
+            : null
+          result = { event: formatEvent(eventRow, resolveData), step: stepRow ? formatStep(stepRow, resolveData) : undefined }
+          break
+        }
+
+        case 'hook_created': {
+          const hookId = randomUUID()
+          const eventData = body.eventData || {}
+          const metadata = eventData.metadata ? encodeData(eventData.metadata) : null
+
+          // ON CONFLICT DO NOTHING handles the partial unique index atomically.
+          // If another active hook with the same token exists, the INSERT is skipped.
+          const insertResult = await client.query(
+            `INSERT INTO workflow_hooks (id, run_id, application_id, correlation_id, token, owner_id, project_id, environment, metadata, spec_version, is_webhook)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+             ON CONFLICT (token) WHERE status = 'pending' DO NOTHING
+             RETURNING id`,
+            [hookId, rawRunId, appId, body.correlationId, eventData.token,
+              eventData.ownerId || '', eventData.projectId || '', eventData.environment || '',
+              metadata, body.specVersion || null, eventData.isWebhook ?? false]
+          )
+
+          if (insertResult.rows.length === 0) {
+            // Token conflict — another active hook already exists
+            const conflictBody = {
+              eventType: 'hook_conflict',
+              correlationId: body.correlationId,
+              eventData: { token: eventData.token },
+              specVersion: body.specVersion,
+            }
+            const eventRow = await insertEvent(client, rawRunId, appId, conflictBody)
+            await client.query('COMMIT')
+            return { event: formatEvent(eventRow, resolveData) }
+          }
+
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const hookRow = (await client.query('SELECT * FROM workflow_hooks WHERE id = $1', [hookId])).rows[0]
+          result = { event: formatEvent(eventRow, resolveData), hook: formatHook(hookRow) }
+          break
+        }
+
+        case 'hook_received': {
+          // Update hook status to received
+          let hookRow = null
+          if (body.correlationId) {
+            const hookResult = await client.query(
+              `UPDATE workflow_hooks SET status = 'received', received_at = NOW()
+               WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3
+               RETURNING *`,
+              [rawRunId, body.correlationId, appId]
+            )
+            if (hookResult.rows.length > 0) hookRow = hookResult.rows[0]
+          }
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          result = { event: formatEvent(eventRow, resolveData), hook: hookRow ? formatHook(hookRow) : undefined }
+          break
+        }
+
+        case 'hook_disposed': {
+          // Mark hook as disposed
+          let hookRow = null
+          if (body.correlationId) {
+            const hookResult = await client.query(
+              `UPDATE workflow_hooks SET status = 'disposed', disposed_at = NOW()
+               WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3
+               RETURNING *`,
+              [rawRunId, body.correlationId, appId]
+            )
+            if (hookResult.rows.length > 0) hookRow = hookResult.rows[0]
+          }
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          result = { event: formatEvent(eventRow, resolveData), hook: hookRow ? formatHook(hookRow) : undefined }
+          break
+        }
+
+        case 'wait_created': {
+          const waitId = randomUUID()
+          const eventData = body.eventData || {}
+          const resumeAt = eventData.resumeAt ? new Date(eventData.resumeAt) : null
+
+          await client.query(
+            `INSERT INTO workflow_waits (id, run_id, application_id, correlation_id, status, resume_at, spec_version)
+             VALUES ($1, $2, $3, $4, 'waiting', $5, $6)`,
+            [waitId, rawRunId, appId, body.correlationId, resumeAt, body.specVersion || null]
+          )
+
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const waitRow = (await client.query('SELECT * FROM workflow_waits WHERE id = $1', [waitId])).rows[0]
+          result = { event: formatEvent(eventRow, resolveData), wait: formatWait(waitRow) }
+          break
+        }
+
+        case 'wait_completed': {
+          const waitResult = await client.query(
+            'SELECT id FROM workflow_waits WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3',
+            [rawRunId, body.correlationId, appId]
+          )
+          if (waitResult.rows.length > 0) {
+            await client.query(
+              `UPDATE workflow_waits SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+               WHERE id = $1`,
+              [waitResult.rows[0].id]
+            )
+          }
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          const waitRow = waitResult.rows.length > 0
+            ? (await client.query('SELECT * FROM workflow_waits WHERE id = $1', [waitResult.rows[0].id])).rows[0]
+            : null
+          result = { event: formatEvent(eventRow, resolveData), wait: waitRow ? formatWait(waitRow) : undefined }
+          break
+        }
+
+        default:
+          throw new BadRequest(`unknown event type: ${body.eventType}`)
+      }
+
+      await client.query('COMMIT')
+      return result
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    } finally {
+      client.release()
+    }
+  })
+
+  // List events for a run
+  app.get('/api/v1/apps/:appId/runs/:runId/events', async (request) => {
+    const { runId } = request.params as { runId: string }
+    const query = request.query as { limit?: string; cursor?: string; sortOrder?: string; resolveData?: string }
+    const appId = request.appId
+    const limit = Math.min(parseInt(query.limit || '100', 10), 1000)
+    const sortOrder = query.sortOrder === 'desc' ? 'DESC' : 'ASC'
+    const cursor = query.cursor ? parseInt(query.cursor, 10) : 0
+
+    const result = await app.pg.query(
+      `SELECT * FROM workflow_events
+       WHERE run_id = $1 AND application_id = $2 AND id > $3
+       ORDER BY id ${sortOrder}
+       LIMIT $4`,
+      [runId, appId, cursor, limit + 1]
+    )
+
+    const hasMore = result.rows.length > limit
+    const data = result.rows.slice(0, limit).map(row => formatEvent(row, query.resolveData))
+    const nextCursor = hasMore && data.length > 0 ? String(result.rows[limit - 1].id) : null
+
+    return { data, cursor: nextCursor, hasMore }
+  })
+
+  // List events by correlation ID
+  app.get('/api/v1/apps/:appId/events/by-correlation', async (request) => {
+    const query = request.query as { correlationId: string; limit?: string; cursor?: string; resolveData?: string }
+    const appId = request.appId
+    const limit = Math.min(parseInt(query.limit || '100', 10), 1000)
+    const cursor = query.cursor ? parseInt(query.cursor, 10) : 0
+
+    const result = await app.pg.query(
+      `SELECT * FROM workflow_events
+       WHERE application_id = $1 AND correlation_id = $2 AND id > $3
+       ORDER BY id ASC
+       LIMIT $4`,
+      [appId, query.correlationId, cursor, limit + 1]
+    )
+
+    const hasMore = result.rows.length > limit
+    const data = result.rows.slice(0, limit).map(row => formatEvent(row, query.resolveData))
+    const nextCursor = hasMore && data.length > 0 ? String(result.rows[limit - 1].id) : null
+
+    return { data, cursor: nextCursor, hasMore }
+  })
+}
+
+export { formatRun, formatStep, formatHook, formatWait, formatEvent, decodeData, encodeData }
+
+export default fp(eventsPlugin, { name: 'events', dependencies: ['auth'] })

--- a/packages/workflow/plugins/handlers.ts
+++ b/packages/workflow/plugins/handlers.ts
@@ -1,0 +1,54 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { BadRequest } from '../lib/errors.ts'
+
+async function handlersPlugin (app: FastifyInstance): Promise<void> {
+  // Register pod queue handler endpoints
+  app.post('/api/v1/apps/:appId/handlers', async (request, reply) => {
+    const appId = request.appId
+    const body = request.body as {
+      podId: string
+      deploymentVersion: string
+      endpoints: {
+        workflow: string
+        step: string
+        webhook: string
+      }
+    }
+
+    if (!body.podId || !body.deploymentVersion || !body.endpoints) {
+      throw new BadRequest('podId, deploymentVersion, and endpoints are required')
+    }
+
+    await app.pg.query(
+      `INSERT INTO workflow_queue_handlers (application_id, pod_id, deployment_version, workflow_url, step_url, webhook_url)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (application_id, pod_id) DO UPDATE SET
+         deployment_version = $3,
+         workflow_url = $4,
+         step_url = $5,
+         webhook_url = $6,
+         last_heartbeat = NOW()`,
+      [appId, body.podId, body.deploymentVersion,
+        body.endpoints.workflow, body.endpoints.step, body.endpoints.webhook]
+    )
+
+    reply.code(201)
+    return { registered: true }
+  })
+
+  // Deregister pod
+  app.delete('/api/v1/apps/:appId/handlers/:podId', async (request) => {
+    const { podId } = request.params as { podId: string }
+    const appId = request.appId
+
+    await app.pg.query(
+      'DELETE FROM workflow_queue_handlers WHERE application_id = $1 AND pod_id = $2',
+      [appId, podId]
+    )
+
+    return { deregistered: true }
+  })
+}
+
+export default fp(handlersPlugin, { name: 'handlers', dependencies: ['auth'] })

--- a/packages/workflow/plugins/hooks.ts
+++ b/packages/workflow/plugins/hooks.ts
@@ -1,0 +1,75 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { HookNotFound } from '../lib/errors.ts'
+import { formatHook } from './events.ts'
+
+async function hooksPlugin (app: FastifyInstance): Promise<void> {
+  // Get hook by ID — prefer non-disposed hooks (logical delete keeps old rows)
+  app.get('/api/v1/apps/:appId/hooks/:hookId', async (request) => {
+    const { hookId } = request.params as { hookId: string }
+    const appId = request.appId
+
+    const result = await app.pg.query(
+      `SELECT * FROM workflow_hooks WHERE correlation_id = $1 AND application_id = $2
+       ORDER BY CASE WHEN status = 'disposed' THEN 1 ELSE 0 END, created_at DESC
+       LIMIT 1`,
+      [hookId, appId]
+    )
+
+    if (result.rows.length === 0) throw new HookNotFound(hookId)
+    return formatHook(result.rows[0])
+  })
+
+  // Get hook by token — prefer pending, then received, then disposed
+  app.get('/api/v1/apps/:appId/hooks/by-token/:token', async (request) => {
+    const { token } = request.params as { token: string }
+    const appId = request.appId
+
+    const result = await app.pg.query(
+      `SELECT * FROM workflow_hooks WHERE token = $1 AND application_id = $2
+       ORDER BY CASE status WHEN 'pending' THEN 0 WHEN 'received' THEN 1 ELSE 2 END, created_at DESC
+       LIMIT 1`,
+      [token, appId]
+    )
+
+    if (result.rows.length === 0) throw new HookNotFound(token)
+    return formatHook(result.rows[0])
+  })
+
+  // List hooks
+  app.get('/api/v1/apps/:appId/hooks', async (request) => {
+    const query = request.query as { runId?: string; limit?: string; cursor?: string }
+    const appId = request.appId
+    const limit = Math.min(parseInt(query.limit || '100', 10), 1000)
+
+    const offset = query.cursor ? parseInt(query.cursor, 10) : 0
+
+    const conditions = ['application_id = $1', "status != 'disposed'"]
+    const params: any[] = [appId]
+    let paramIdx = 2
+
+    if (query.runId) {
+      conditions.push(`run_id = $${paramIdx++}`)
+      params.push(query.runId)
+    }
+
+    params.push(limit + 1)
+    params.push(offset)
+
+    const result = await app.pg.query(
+      `SELECT * FROM workflow_hooks
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY created_at ASC
+       LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+      params
+    )
+
+    const hasMore = result.rows.length > limit
+    const data = result.rows.slice(0, limit).map(formatHook)
+    const nextCursor = hasMore ? String(offset + limit) : null
+
+    return { data, cursor: nextCursor, hasMore }
+  })
+}
+
+export default fp(hooksPlugin, { name: 'hooks', dependencies: ['auth'] })

--- a/packages/workflow/plugins/poller.ts
+++ b/packages/workflow/plugins/poller.ts
@@ -1,0 +1,13 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { createPoller } from '../queue/poller.ts'
+
+async function pollerPlugin (app: FastifyInstance): Promise<void> {
+  if (process.env.WF_ENABLE_POLLER === 'false') return
+
+  const poller = createPoller(app.pg, app.pgConnectionString, app.log)
+  app.addHook('onReady', async () => { poller.start() })
+  app.addHook('onClose', async () => { await poller.stop() })
+}
+
+export default fp(pollerPlugin, { name: 'poller', dependencies: ['db', 'auth'] })

--- a/packages/workflow/plugins/queue.ts
+++ b/packages/workflow/plugins/queue.ts
@@ -1,0 +1,98 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { DuplicateIdempotencyKey, BadRequest } from '../lib/errors.ts'
+import { checkQueueRateLimit } from '../lib/quotas.ts'
+
+async function queuePlugin (app: FastifyInstance): Promise<void> {
+  app.post('/api/v1/apps/:appId/queue', async (request, reply) => {
+    const appId = request.appId
+    const body = request.body as {
+      queueName: string
+      message: any
+      deploymentId?: string
+      idempotencyKey?: string
+      delaySeconds?: number
+    }
+
+    if (!body.queueName || !body.message) {
+      throw new BadRequest('queueName and message are required')
+    }
+
+    await checkQueueRateLimit(app, appId)
+
+    // Extract runId from payload
+    const runId = body.message.runId || body.message.workflowRunId || ''
+    const deploymentVersion = body.deploymentId || ''
+
+    // Check idempotency
+    if (body.idempotencyKey) {
+      const existing = await app.pg.query(
+        'SELECT id FROM workflow_queue_messages WHERE idempotency_key = $1',
+        [body.idempotencyKey]
+      )
+      if (existing.rows.length > 0) {
+        throw new DuplicateIdempotencyKey(body.idempotencyKey)
+      }
+    }
+
+    const delaySeconds = body.delaySeconds || 0
+
+    if (delaySeconds > 0) {
+      // Deferred delivery
+      const cappedDelay = delaySeconds
+      let result
+      try {
+        result = await app.pg.query(
+          `INSERT INTO workflow_queue_messages
+           (idempotency_key, queue_name, run_id, deployment_version, application_id, payload, status, deliver_at)
+           VALUES ($1, $2, $3, $4, $5, $6, 'deferred', NOW() + make_interval(secs => $7))
+           RETURNING id`,
+          [body.idempotencyKey || null, body.queueName, runId, deploymentVersion, appId,
+            JSON.stringify(body.message), cappedDelay]
+        )
+      } catch (err: any) {
+        if (err.code === '23505') throw new DuplicateIdempotencyKey(body.idempotencyKey || '')
+        throw err
+      }
+
+      const messageId = result.rows[0].id
+
+      // Wake the executor so it can recalculate its timer
+      await app.pg.query("SELECT pg_notify('deferred_messages', '{}')")
+
+      reply.code(201)
+      return {
+        messageId: `msg_${messageId}`,
+        scheduled: true,
+        deliverAt: new Date(Date.now() + cappedDelay * 1000).toISOString(),
+      }
+    }
+
+    // Immediate delivery — insert as pending and let the poller dispatch asynchronously.
+    // This prevents synchronous dispatch chains that block the SDK's Promise.race().
+    let insertResult
+    try {
+      insertResult = await app.pg.query(
+        `INSERT INTO workflow_queue_messages
+         (idempotency_key, queue_name, run_id, deployment_version, application_id, payload, status)
+         VALUES ($1, $2, $3, $4, $5, $6, 'pending')
+         RETURNING id`,
+        [body.idempotencyKey || null, body.queueName, runId, deploymentVersion, appId,
+          JSON.stringify(body.message)]
+      )
+    } catch (err: any) {
+      if (err.code === '23505') throw new DuplicateIdempotencyKey(body.idempotencyKey || '')
+      throw err
+    }
+
+    const messageId = insertResult.rows[0].id
+
+    // Wake the poller to dispatch this message asynchronously
+    await app.pg.query("SELECT pg_notify('deferred_messages', '{}')")
+
+    reply.code(201)
+    return { messageId: `msg_${messageId}` }
+  })
+}
+
+export default fp(queuePlugin, { name: 'queue', dependencies: ['auth'] })

--- a/packages/workflow/plugins/runs.ts
+++ b/packages/workflow/plugins/runs.ts
@@ -1,0 +1,75 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { RunNotFound } from '../lib/errors.ts'
+import { formatRun } from './events.ts'
+
+async function runsPlugin (app: FastifyInstance): Promise<void> {
+  // Get run by ID
+  app.get('/api/v1/apps/:appId/runs/:runId', async (request) => {
+    const { runId } = request.params as { runId: string }
+    const query = request.query as { resolveData?: string }
+    const appId = request.appId
+
+    const result = await app.pg.query(
+      'SELECT * FROM workflow_runs WHERE id = $1 AND application_id = $2',
+      [runId, appId]
+    )
+
+    if (result.rows.length === 0) throw new RunNotFound(runId)
+    return formatRun(result.rows[0], query.resolveData)
+  })
+
+  // List runs
+  app.get('/api/v1/apps/:appId/runs', async (request) => {
+    const query = request.query as {
+      workflowName?: string
+      status?: string
+      deploymentId?: string
+      limit?: string
+      cursor?: string
+      resolveData?: string
+    }
+    const appId = request.appId
+    const limit = Math.min(parseInt(query.limit || '50', 10), 1000)
+    const conditions = ['application_id = $1']
+    const params: any[] = [appId]
+    let paramIdx = 2
+
+    if (query.workflowName) {
+      conditions.push(`workflow_name = $${paramIdx++}`)
+      params.push(query.workflowName)
+    }
+    if (query.status) {
+      conditions.push(`status = $${paramIdx++}`)
+      params.push(query.status)
+    }
+    if (query.deploymentId) {
+      conditions.push(`deployment_id = $${paramIdx++}`)
+      params.push(query.deploymentId)
+    }
+    if (query.cursor) {
+      conditions.push(`created_at < $${paramIdx++}`)
+      params.push(new Date(query.cursor))
+    }
+
+    params.push(limit + 1)
+
+    const result = await app.pg.query(
+      `SELECT * FROM workflow_runs
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY created_at DESC
+       LIMIT $${paramIdx}`,
+      params
+    )
+
+    const hasMore = result.rows.length > limit
+    const data = result.rows.slice(0, limit).map(row => formatRun(row, query.resolveData))
+    const nextCursor = hasMore && data.length > 0
+      ? result.rows[limit - 1].created_at.toISOString()
+      : null
+
+    return { data, cursor: nextCursor, hasMore }
+  })
+}
+
+export default fp(runsPlugin, { name: 'runs', dependencies: ['auth'] })

--- a/packages/workflow/plugins/steps.ts
+++ b/packages/workflow/plugins/steps.ts
@@ -1,0 +1,46 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { StepNotFound } from '../lib/errors.ts'
+import { formatStep } from './events.ts'
+
+async function stepsPlugin (app: FastifyInstance): Promise<void> {
+  // Get step by ID
+  app.get('/api/v1/apps/:appId/runs/:runId/steps/:stepId', async (request) => {
+    const { runId, stepId } = request.params as { runId: string; stepId: string }
+    const query = request.query as { resolveData?: string }
+    const appId = request.appId
+
+    const result = await app.pg.query(
+      'SELECT * FROM workflow_steps WHERE id = $1 AND run_id = $2 AND application_id = $3',
+      [stepId, runId, appId]
+    )
+
+    if (result.rows.length === 0) throw new StepNotFound(stepId)
+    return formatStep(result.rows[0], query.resolveData)
+  })
+
+  // List steps for a run
+  app.get('/api/v1/apps/:appId/runs/:runId/steps', async (request) => {
+    const { runId } = request.params as { runId: string }
+    const query = request.query as { limit?: string; cursor?: string; resolveData?: string }
+    const appId = request.appId
+    const limit = Math.min(parseInt(query.limit || '100', 10), 1000)
+    const offset = query.cursor ? parseInt(query.cursor, 10) : 0
+
+    const result = await app.pg.query(
+      `SELECT * FROM workflow_steps
+       WHERE run_id = $1 AND application_id = $2
+       ORDER BY created_at ASC
+       LIMIT $3 OFFSET $4`,
+      [runId, appId, limit + 1, offset]
+    )
+
+    const hasMore = result.rows.length > limit
+    const data = result.rows.slice(0, limit).map(row => formatStep(row, query.resolveData))
+    const nextCursor = hasMore ? String(offset + limit) : null
+
+    return { data, cursor: nextCursor, hasMore }
+  })
+}
+
+export default fp(stepsPlugin, { name: 'steps', dependencies: ['auth'] })

--- a/packages/workflow/plugins/streams.ts
+++ b/packages/workflow/plugins/streams.ts
@@ -1,0 +1,295 @@
+import fp from 'fastify-plugin'
+import { EventEmitter } from 'node:events'
+import pg from 'pg'
+import type { FastifyInstance } from 'fastify'
+import { BadRequest } from '../lib/errors.ts'
+
+function isHealthCheckStream (name: string): boolean {
+  return name.startsWith('__health_check__')
+}
+
+async function streamsPlugin (app: FastifyInstance): Promise<void> {
+  // Shared LISTEN client + EventEmitter for stream notifications
+  const streamEvents = new EventEmitter()
+  let listenClient: pg.Client | null = null
+
+  // In-memory storage for health check streams (no real run_id, skip DB)
+  const healthStreams = new Map<string, { chunks: Buffer[]; closed: boolean }>()
+
+  async function setupListener (): Promise<void> {
+    listenClient = new pg.Client({ connectionString: app.pgConnectionString })
+    await listenClient.connect()
+    await listenClient.query('LISTEN stream_update')
+    listenClient.on('notification', (msg) => {
+      if (msg.channel === 'stream_update' && msg.payload) {
+        streamEvents.emit(msg.payload)
+      }
+    })
+  }
+
+  await setupListener()
+
+  app.addHook('onClose', async () => {
+    if (listenClient) {
+      await listenClient.end()
+      listenClient = null
+    }
+  })
+
+  async function notifyStream (streamName: string): Promise<void> {
+    if (isHealthCheckStream(streamName)) {
+      // Health check streams are in-memory only — emit directly
+      streamEvents.emit(streamName)
+      return
+    }
+    await app.pg.query("SELECT pg_notify('stream_update', $1)", [streamName])
+  }
+
+  // Write chunk(s) to a stream
+  app.put('/api/v1/apps/:appId/runs/:runId/streams/:name', async (request, reply) => {
+    const { runId, name } = request.params as { runId: string; name: string }
+    const appId = request.appId
+    const isMulti = request.headers['x-stream-multi'] === 'true'
+    const isDone = request.headers['x-stream-done'] === 'true'
+
+    // Health check streams bypass the DB (no real run_id)
+    if (isHealthCheckStream(name)) {
+      if (!healthStreams.has(name)) {
+        healthStreams.set(name, { chunks: [], closed: false })
+      }
+      const hs = healthStreams.get(name)!
+
+      if (isDone) {
+        hs.closed = true
+      } else if (isMulti) {
+        const chunks = request.body as any[]
+        if (!Array.isArray(chunks)) throw new BadRequest('body must be an array for multi-write')
+        for (const chunk of chunks) {
+          const data = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : Buffer.from(chunk.data || chunk, 'base64')
+          hs.chunks.push(data)
+        }
+      } else {
+        const body = request.body as any
+        const data = typeof body === 'string'
+          ? Buffer.from(body, 'utf-8')
+          : Buffer.isBuffer(body)
+            ? body
+            : Buffer.from(body.data || JSON.stringify(body), 'base64')
+        hs.chunks.push(data)
+      }
+
+      await notifyStream(name)
+      reply.code(204)
+      return
+    }
+
+    if (isDone) {
+      await app.pg.query(
+        `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data, is_closed)
+         VALUES ($1, $2, $3, -1, $4, TRUE)
+         ON CONFLICT DO NOTHING`,
+        [name, runId, appId, Buffer.alloc(0)]
+      )
+      await notifyStream(name)
+      reply.code(204)
+      return
+    }
+
+    if (isMulti) {
+      const chunks = request.body as any[]
+      if (!Array.isArray(chunks)) throw new BadRequest('body must be an array for multi-write')
+
+      const maxResult = await app.pg.query(
+        `SELECT COALESCE(MAX(chunk_index), -1) as max_idx FROM workflow_stream_chunks
+         WHERE stream_name = $1 AND run_id = $2 AND application_id = $3 AND is_closed = FALSE`,
+        [name, runId, appId]
+      )
+      let idx = maxResult.rows[0].max_idx + 1
+
+      const client = await app.pg.connect()
+      try {
+        await client.query('BEGIN')
+        for (const chunk of chunks) {
+          const data = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : Buffer.from(chunk.data || chunk, 'base64')
+          await client.query(
+            `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data)
+             VALUES ($1, $2, $3, $4, $5)`,
+            [name, runId, appId, idx++, data]
+          )
+        }
+        await client.query('COMMIT')
+      } catch (err) {
+        await client.query('ROLLBACK')
+        throw err
+      } finally {
+        client.release()
+      }
+    } else {
+      const body = request.body as any
+      const data = typeof body === 'string'
+        ? Buffer.from(body, 'utf-8')
+        : Buffer.isBuffer(body)
+          ? body
+          : Buffer.from(body.data || JSON.stringify(body), 'base64')
+
+      const maxResult = await app.pg.query(
+        `SELECT COALESCE(MAX(chunk_index), -1) as max_idx FROM workflow_stream_chunks
+         WHERE stream_name = $1 AND run_id = $2 AND application_id = $3 AND is_closed = FALSE`,
+        [name, runId, appId]
+      )
+      const idx = maxResult.rows[0].max_idx + 1
+
+      await app.pg.query(
+        `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [name, runId, appId, idx, data]
+      )
+    }
+
+    await notifyStream(name)
+    reply.code(204)
+  })
+
+  // Read stream chunks — streaming mode (stream=true) uses LISTEN/NOTIFY
+  app.get('/api/v1/apps/:appId/streams/:name', async (request, reply) => {
+    const { name } = request.params as { name: string }
+    const query = request.query as { startIndex?: string; stream?: string }
+    const appId = request.appId
+    const startIndex = parseInt(query.startIndex || '0', 10)
+
+    if (query.stream === 'true') {
+      reply.raw.writeHead(200, { 'content-type': 'application/octet-stream' })
+
+      // Health check streams use in-memory storage
+      if (isHealthCheckStream(name)) {
+        let done = false
+
+        function flushHealth (): void {
+          const hs = healthStreams.get(name)
+          if (!hs) return
+
+          for (const buf of hs.chunks) {
+            if (buf.byteLength > 0) {
+              reply.raw.write(buf)
+            }
+          }
+          hs.chunks = []
+
+          if (hs.closed) {
+            done = true
+            reply.raw.end()
+            healthStreams.delete(name)
+          }
+        }
+
+        flushHealth()
+        if (done) return reply
+
+        return new Promise((resolve) => {
+          const onUpdate = () => {
+            if (done) return
+            flushHealth()
+            if (done) {
+              streamEvents.removeListener(name, onUpdate)
+              resolve(reply)
+            }
+          }
+          streamEvents.on(name, onUpdate)
+
+          request.raw.on('close', () => {
+            done = true
+            streamEvents.removeListener(name, onUpdate)
+            resolve(reply)
+          })
+        })
+      }
+
+      let nextIndex = startIndex
+      let done = false
+
+      async function flush (): Promise<void> {
+        const result = await app.pg.query(
+          `SELECT data, chunk_index FROM workflow_stream_chunks
+           WHERE stream_name = $1 AND application_id = $2 AND chunk_index >= $3 AND is_closed = FALSE
+           ORDER BY chunk_index ASC`,
+          [name, appId, nextIndex]
+        )
+
+        for (const row of result.rows) {
+          const buf = row.data as Buffer
+          if (buf.byteLength > 0) {
+            reply.raw.write(buf)
+          }
+          nextIndex = row.chunk_index + 1
+        }
+
+        const closedResult = await app.pg.query(
+          `SELECT 1 FROM workflow_stream_chunks
+           WHERE stream_name = $1 AND application_id = $2 AND is_closed = TRUE
+           LIMIT 1`,
+          [name, appId]
+        )
+
+        if (closedResult.rows.length > 0) {
+          done = true
+          reply.raw.end()
+        }
+      }
+
+      // Flush any existing chunks first
+      await flush()
+      if (done) return reply
+
+      // Wait for NOTIFY events to flush new chunks
+      return new Promise((resolve) => {
+        const onUpdate = async () => {
+          if (done) return
+          await flush()
+          if (done) {
+            streamEvents.removeListener(name, onUpdate)
+            resolve(reply)
+          }
+        }
+        streamEvents.on(name, onUpdate)
+
+        // Clean up if client disconnects
+        request.raw.on('close', () => {
+          done = true
+          streamEvents.removeListener(name, onUpdate)
+          resolve(reply)
+        })
+      })
+    }
+
+    // Legacy binary mode
+    const result = await app.pg.query(
+      `SELECT data, chunk_index FROM workflow_stream_chunks
+       WHERE stream_name = $1 AND application_id = $2 AND chunk_index >= $3 AND is_closed = FALSE
+       ORDER BY chunk_index ASC`,
+      [name, appId, startIndex]
+    )
+
+    reply.header('content-type', 'application/octet-stream')
+    const chunks = result.rows.map(row => row.data)
+    if (chunks.length === 0) {
+      return Buffer.alloc(0)
+    }
+    return Buffer.concat(chunks)
+  })
+
+  // List streams for a run
+  app.get('/api/v1/apps/:appId/runs/:runId/streams', async (request) => {
+    const { runId } = request.params as { runId: string }
+    const appId = request.appId
+
+    const result = await app.pg.query(
+      `SELECT DISTINCT stream_name FROM workflow_stream_chunks
+       WHERE run_id = $1 AND application_id = $2`,
+      [runId, appId]
+    )
+
+    return result.rows.map(row => row.stream_name)
+  })
+}
+
+export default fp(streamsPlugin, { name: 'streams', dependencies: ['auth'] })

--- a/packages/workflow/plugins/versions.ts
+++ b/packages/workflow/plugins/versions.ts
@@ -1,0 +1,43 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { Forbidden, BadRequest } from '../lib/errors.ts'
+
+async function versionsPlugin (app: FastifyInstance): Promise<void> {
+  // Version notification — called by ICC
+  app.post('/api/v1/versions/notify', async (request) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const body = request.body as {
+      applicationId: string
+      deploymentVersion: string
+      status: 'active' | 'draining' | 'expired'
+    }
+
+    if (!body.applicationId || !body.deploymentVersion || !body.status) {
+      throw new BadRequest('applicationId, deploymentVersion, and status are required')
+    }
+
+    const appResult = await app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1',
+      [body.applicationId]
+    )
+    if (appResult.rows.length === 0) {
+      throw new BadRequest(`application ${body.applicationId} not found`)
+    }
+
+    const applicationId = appResult.rows[0].id
+
+    await app.pg.query(
+      `INSERT INTO workflow_deployment_versions (application_id, deployment_version, status)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (application_id, deployment_version) DO UPDATE SET
+         status = $3,
+         updated_at = NOW()`,
+      [applicationId, body.deploymentVersion, body.status]
+    )
+
+    return { updated: true }
+  })
+}
+
+export default fp(versionsPlugin, { name: 'versions', dependencies: ['auth'] })

--- a/packages/workflow/queue/dispatcher.ts
+++ b/packages/workflow/queue/dispatcher.ts
@@ -1,0 +1,69 @@
+import { request as undiciRequest } from 'undici'
+
+export interface DispatchResult {
+  success: boolean
+  timeoutSeconds?: number
+  statusCode: number
+}
+
+export async function dispatchMessage (
+  url: string,
+  queueName: string,
+  messageId: number,
+  message: unknown,
+  attempt: number
+): Promise<DispatchResult> {
+  try {
+    const response = await undiciRequest(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        message,
+        meta: {
+          queueName,
+          messageId: `msg_${messageId}`,
+          attempt,
+        },
+      }),
+      headersTimeout: 30_000,
+      bodyTimeout: 300_000, // 5 minutes for step execution
+    })
+
+    const statusCode = response.statusCode
+
+    if (statusCode >= 200 && statusCode < 300) {
+      try {
+        const body = await response.body.json() as { timeoutSeconds?: number }
+        return {
+          success: true,
+          timeoutSeconds: body?.timeoutSeconds,
+          statusCode,
+        }
+      } catch {
+        await response.body.dump()
+        return { success: true, statusCode }
+      }
+    }
+
+    // 425 = step retryAfter not reached yet — extract the retryAfter and
+    // treat as a deferred re-queue instead of a failure (avoids double backoff)
+    if (statusCode === 425) {
+      let delaySecs = 1
+      try {
+        const body = await response.body.json() as { meta?: { retryAfter?: string } }
+        if (body?.meta?.retryAfter) {
+          const retryAt = new Date(body.meta.retryAfter)
+          delaySecs = Math.max(1, Math.ceil((retryAt.getTime() - Date.now()) / 1000))
+        }
+      } catch {
+        await response.body.dump()
+      }
+      return { success: true, timeoutSeconds: delaySecs, statusCode }
+    }
+
+    await response.body.dump()
+    return { success: false, statusCode }
+  } catch {
+    return { success: false, statusCode: 0 }
+  }
+}

--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -1,0 +1,310 @@
+import pg from 'pg'
+import createLeaderElector from '@platformatic/leader'
+import { routeMessage } from './router.ts'
+import { dispatchMessage, type DispatchResult } from './dispatcher.ts'
+import { getRetryDelay, isMaxAttempts } from './retry.ts'
+
+const ORPHAN_CHECK_INTERVAL = 60_000
+const LEADER_LOCK_ID = 42424242
+const DEFERRED_CHANNEL = 'deferred_messages'
+
+export function createPoller (pool: pg.Pool, connectionString: string, log: any) {
+  let stopped = false
+  let deferredTimer: ReturnType<typeof setTimeout> | null = null
+  let orphanTimer: ReturnType<typeof setInterval> | null = null
+  let listenClient: pg.Client | null = null
+  let executing = false
+  let pendingNotify = false
+
+  // Leader election only — dummy channel required by @platformatic/leader@0.1.0
+  // TODO: remove channels once @platformatic/leader supports election-only mode
+  const leader = createLeaderElector({
+    pool,
+    lock: LEADER_LOCK_ID,
+    log,
+    channels: [{ channel: '__leader_noop__', onNotification: () => {} }],
+    onLeadershipChange: (isLeader: boolean) => {
+      if (isLeader) {
+        startPolling()
+      } else {
+        stopPolling()
+      }
+    },
+  })
+
+  function startPolling (): void {
+    stopped = false
+    setupListener()
+    orphanTimer = setInterval(checkOrphans, ORPHAN_CHECK_INTERVAL)
+    execute()
+  }
+
+  function stopPolling (): void {
+    stopped = true
+    if (deferredTimer) { clearTimeout(deferredTimer); deferredTimer = null }
+    if (orphanTimer) { clearInterval(orphanTimer); orphanTimer = null }
+    teardownListener()
+  }
+
+  // Dedicated LISTEN client — not from the pool
+  function setupListener (): void {
+    listenClient = new pg.Client({ connectionString })
+    listenClient.on('error', (err) => {
+      log.error({ err }, 'LISTEN connection error')
+      if (!stopped && leader.isLeader()) {
+        setTimeout(() => setupListener(), 1000)
+      }
+    })
+
+    listenClient.connect()
+      .then(() => listenClient!.query(`LISTEN "${DEFERRED_CHANNEL}"`))
+      .then(() => {
+        log.info({ channel: DEFERRED_CHANNEL }, 'Listening to notification channel')
+      })
+      .catch((err) => {
+        log.error({ err }, 'Failed to setup LISTEN connection')
+        if (!stopped && leader.isLeader()) {
+          setTimeout(() => setupListener(), 1000)
+        }
+      })
+
+    listenClient.on('notification', () => {
+      execute()
+    })
+  }
+
+  function teardownListener (): void {
+    if (listenClient) {
+      listenClient.end().catch(() => {})
+      listenClient = null
+    }
+  }
+
+  async function execute (): Promise<void> {
+    if (stopped) return
+
+    if (executing) {
+      pendingNotify = true
+      return
+    }
+    executing = true
+
+    try {
+      await executeOnce()
+    } finally {
+      executing = false
+      if (pendingNotify && !stopped) {
+        pendingNotify = false
+        setImmediate(() => execute())
+      }
+    }
+  }
+
+  async function executeOnce (): Promise<void> {
+    const client = await pool.connect()
+    try {
+      // 1. Promote deferred messages that are due
+      await client.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'pending'
+         WHERE status = 'deferred' AND deliver_at <= NOW()`
+      )
+
+      // 2. Retry failed messages that are due
+      await client.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'pending'
+         WHERE status = 'failed' AND next_retry_at <= NOW() AND attempts < 10`
+      )
+
+      // 3. Dispatch all pending messages
+      const pending = await client.query(
+        `SELECT * FROM workflow_queue_messages
+         WHERE status = 'pending'
+         ORDER BY created_at ASC
+         FOR UPDATE SKIP LOCKED
+         LIMIT 100`
+      )
+
+      // Dispatch all messages concurrently (HTTP calls in parallel)
+      // then process results sequentially (DB updates on same client)
+      const dispatchResults = await Promise.all(
+        pending.rows.map(async (msg: any) => {
+          const route = await routeMessage(pool, msg.application_id, msg.deployment_version, msg.queue_name)
+          if (!route) {
+            return { msg, route: null, result: null }
+          }
+          const result = await dispatchMessage(
+            route.url, msg.queue_name, msg.id, msg.payload, msg.attempts
+          )
+          log.info(`[POLLER] dispatched msgId=${msg.id} queue=${msg.queue_name} status=${result.statusCode} timeoutSeconds=${result.timeoutSeconds} success=${result.success}`)
+          return { msg, route, result }
+        })
+      )
+
+      for (const { msg, route, result } of dispatchResults) {
+        if (!route || !result) {
+          await handleNoRoute(client, msg)
+          continue
+        }
+        await handleDispatchResult(client, msg, result)
+      }
+
+      // 4. Schedule next wake-up based on earliest deferred/retry message
+      // Fire-and-forget: must not block executeOnce so pendingNotify re-runs
+      // are not delayed, and so re-runs use their own pool connection for the query
+      scheduleNextWakeup()
+    } catch (err) {
+      log.error({ err }, 'Executor error')
+    } finally {
+      client.release()
+    }
+  }
+
+  async function checkOrphans (): Promise<void> {
+    if (stopped) return
+
+    const client = await pool.connect()
+    try {
+      const orphans = await client.query(
+        `SELECT id, application_id, deployment_id FROM workflow_runs
+         WHERE status = 'running'
+           AND updated_at < NOW() - INTERVAL '15 minutes'
+           AND id NOT IN (
+             SELECT DISTINCT run_id FROM workflow_queue_messages
+             WHERE status IN ('pending', 'deferred', 'failed')
+           )
+         LIMIT 10`
+      )
+
+      for (const orphan of orphans.rows) {
+        await client.query(
+          `UPDATE workflow_runs SET status = 'failed', error = $2, completed_at = NOW(), updated_at = NOW()
+           WHERE id = $1`,
+          [orphan.id, JSON.stringify({ message: 'Run orphaned: no activity for 15 minutes', code: 'ORPHANED' })]
+        )
+        await client.query(
+          `INSERT INTO workflow_events (run_id, application_id, event_type, event_data)
+           VALUES ($1, $2, 'run_failed', NULL)`,
+          [orphan.id, orphan.application_id]
+        )
+      }
+    } catch (err) {
+      log.error({ err }, 'Orphan check error')
+    } finally {
+      client.release()
+    }
+  }
+
+  async function scheduleNextWakeup (): Promise<void> {
+    if (stopped) return
+    if (deferredTimer) {
+      clearTimeout(deferredTimer)
+      deferredTimer = null
+    }
+
+    try {
+      const result = await pool.query(
+        `SELECT EXTRACT(EPOCH FROM (MIN(next_time) - NOW())) AS secs
+         FROM (
+           SELECT deliver_at AS next_time FROM workflow_queue_messages
+             WHERE status = 'deferred' AND deliver_at > NOW()
+           UNION ALL
+           SELECT next_retry_at AS next_time FROM workflow_queue_messages
+             WHERE status = 'failed' AND next_retry_at > NOW() AND attempts < 10
+         ) t`
+      )
+
+      const secs = result.rows[0]?.secs
+      if (secs !== null && secs !== undefined) {
+        const ms = Math.max(Math.ceil(Number(secs) * 1000), 50)
+        deferredTimer = setTimeout(() => {
+          deferredTimer = null
+          execute()
+        }, ms)
+      }
+    } catch (err) {
+      log.error({ err }, 'Schedule wakeup error')
+    }
+  }
+
+  async function handleNoRoute (client: pg.PoolClient, msg: any): Promise<void> {
+    if (isMaxAttempts(msg.attempts)) {
+      await client.query(
+        `UPDATE workflow_queue_messages SET status = 'dead', updated_at = NOW()
+         WHERE id = $1`,
+        [msg.id]
+      )
+    } else {
+      const delay = getRetryDelay(msg.attempts)
+      await client.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'failed', attempts = attempts + 1,
+             next_retry_at = NOW() + make_interval(secs => $2)
+         WHERE id = $1`,
+        [msg.id, delay / 1000]
+      )
+    }
+  }
+
+  async function handleDispatchResult (client: pg.PoolClient, msg: any, result: DispatchResult): Promise<void> {
+    if (result.success) {
+      if (typeof result.timeoutSeconds === 'number' && result.timeoutSeconds > 0) {
+        const delaySecs = result.timeoutSeconds
+        await client.query(
+          `INSERT INTO workflow_queue_messages
+           (queue_name, run_id, deployment_version, application_id, payload, status, deliver_at)
+           VALUES ($1, $2, $3, $4, $5, 'deferred', NOW() + make_interval(secs => $6))`,
+          [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
+            JSON.stringify(msg.payload), delaySecs]
+        )
+        await client.query("SELECT pg_notify('deferred_messages', '{}')")
+      } else if (typeof result.timeoutSeconds === 'number' && result.timeoutSeconds === 0) {
+        await client.query(
+          `INSERT INTO workflow_queue_messages
+           (queue_name, run_id, deployment_version, application_id, payload, status)
+           VALUES ($1, $2, $3, $4, $5, 'pending')`,
+          [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
+            JSON.stringify(msg.payload)]
+        )
+        await client.query("SELECT pg_notify('deferred_messages', '{}')")
+      }
+      await client.query(
+        `UPDATE workflow_queue_messages SET status = 'delivered', delivered_at = NOW()
+         WHERE id = $1`,
+        [msg.id]
+      )
+    } else {
+      const attempts = msg.attempts + 1
+      if (isMaxAttempts(attempts)) {
+        await client.query(
+          `UPDATE workflow_queue_messages SET status = 'dead', attempts = $2
+           WHERE id = $1`,
+          [msg.id, attempts]
+        )
+      } else {
+        const delay = getRetryDelay(attempts)
+        await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'failed', attempts = $2,
+               next_retry_at = NOW() + make_interval(secs => $3)
+           WHERE id = $1`,
+          [msg.id, attempts, delay / 1000]
+        )
+      }
+    }
+  }
+
+  return {
+    start () {
+      stopped = false
+      leader.start()
+    },
+    async stop () {
+      stopped = true
+      stopPolling()
+      teardownListener()
+      await leader.stop()
+    },
+  }
+}

--- a/packages/workflow/queue/retry.ts
+++ b/packages/workflow/queue/retry.ts
@@ -1,0 +1,13 @@
+const MAX_ATTEMPTS = 10
+const BASE_DELAY_MS = 1000
+const MAX_DELAY_MS = 60_000
+
+export function getRetryDelay (attempt: number): number {
+  return Math.min(BASE_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS)
+}
+
+export function isMaxAttempts (attempt: number): boolean {
+  return attempt >= MAX_ATTEMPTS
+}
+
+export { MAX_ATTEMPTS }

--- a/packages/workflow/queue/router.ts
+++ b/packages/workflow/queue/router.ts
@@ -1,0 +1,49 @@
+import type pg from 'pg'
+
+export interface RouteResult {
+  url: string
+  podId: string
+}
+
+export async function routeMessage (
+  pool: pg.Pool,
+  appId: number,
+  deploymentVersion: string,
+  queueName: string
+): Promise<RouteResult | null> {
+  // Check version status
+  const versionResult = await pool.query(
+    `SELECT status FROM workflow_deployment_versions
+     WHERE application_id = $1 AND deployment_version = $2`,
+    [appId, deploymentVersion]
+  )
+
+  if (versionResult.rows.length > 0 && versionResult.rows[0].status === 'expired') {
+    return null // Version expired
+  }
+
+  // Find registered handlers for this version
+  const handlers = await pool.query(
+    `SELECT pod_id, workflow_url, step_url, webhook_url FROM workflow_queue_handlers
+     WHERE application_id = $1 AND deployment_version = $2
+     ORDER BY last_heartbeat DESC`,
+    [appId, deploymentVersion]
+  )
+
+  if (handlers.rows.length === 0) return null
+
+  // Round-robin: pick based on a simple random selection
+  const handler = handlers.rows[Math.floor(Math.random() * handlers.rows.length)]
+
+  // Determine target URL based on queue name
+  let url: string
+  if (queueName.startsWith('__wkf_step_')) {
+    url = handler.step_url
+  } else if (queueName.startsWith('__wkf_workflow_')) {
+    url = handler.workflow_url
+  } else {
+    url = handler.webhook_url
+  }
+
+  return { url, podId: handler.pod_id }
+}

--- a/packages/workflow/test/auth.test.ts
+++ b/packages/workflow/test/auth.test.ts
@@ -30,12 +30,4 @@ describe('auth - single-tenant mode', () => {
     })
     assert.equal(response.statusCode, 201)
   })
-
-  it('should allow public paths without auth', async () => {
-    const ready = await ctx.app.inject({ method: 'GET', url: '/ready' })
-    assert.equal(ready.statusCode, 200)
-
-    const status = await ctx.app.inject({ method: 'GET', url: '/status' })
-    assert.equal(status.statusCode, 200)
-  })
 })

--- a/packages/workflow/test/executor.test.ts
+++ b/packages/workflow/test/executor.test.ts
@@ -1,9 +1,13 @@
 import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Fastify from 'fastify'
+import autoload from '@fastify/autoload'
 import pg from 'pg'
-import { buildApp } from '../src/app.ts'
 import type { FastifyInstance } from 'fastify'
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
 const CONNECTION_STRING = process.env.DATABASE_URL || 'postgresql://wf:wf@localhost:5434/workflow'
 
 let app: FastifyInstance
@@ -13,12 +17,12 @@ let appNumericId: number
 before(async () => {
   appId = 'executor-test-app'
 
-  app = await buildApp({
-    connectionString: CONNECTION_STRING,
-    singleTenant: true,
-    defaultAppId: appId,
-    enablePoller: false,
-  })
+  process.env.DATABASE_URL = CONNECTION_STRING
+  process.env.PLT_WORLD_APP_ID = appId
+  process.env.WF_ENABLE_POLLER = 'false'
+
+  app = Fastify({ logger: false })
+  await app.register(autoload, { dir: join(__dirname, '..', 'plugins') })
   await app.ready()
 
   const result = await app.pg.query(
@@ -54,7 +58,7 @@ test('NOTIFY wakes up deferred message processing', async () => {
     ['test-queue', '', '', appNumericId, JSON.stringify({ test: true })]
   )
 
-  await app.pg.query("SELECT pg_notify('deferred_messages', '')")
+  await app.pg.query("SELECT pg_notify('deferred_messages', '{}')")
 
   const client = new pg.Client({ connectionString: CONNECTION_STRING })
   await client.connect()
@@ -76,7 +80,7 @@ test('NOTIFY wakes up deferred message processing', async () => {
        VALUES ($1, $2, $3, $4, $5, 'deferred', NOW() + make_interval(secs => 1))`,
       ['test-queue-2', '', '', appNumericId, JSON.stringify({ test: 2 })]
     )
-    await app.pg.query("SELECT pg_notify('deferred_messages', '')")
+    await app.pg.query("SELECT pg_notify('deferred_messages', '{}')")
 
     const notification = await notificationPromise
     assert.equal(notification.channel, 'deferred_messages')

--- a/packages/workflow/test/helper.ts
+++ b/packages/workflow/test/helper.ts
@@ -1,7 +1,11 @@
 import { randomBytes } from 'node:crypto'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Fastify from 'fastify'
+import autoload from '@fastify/autoload'
 import type { FastifyInstance } from 'fastify'
-import { buildApp } from '../src/app.ts'
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
 const BASE_CONNECTION_STRING = process.env.DATABASE_URL || 'postgresql://wf:wf@localhost:5434/workflow'
 
 export interface TestContext {
@@ -12,13 +16,12 @@ export interface TestContext {
 export async function setupTest (): Promise<TestContext> {
   const appIdStr = `test-app-${randomBytes(4).toString('hex')}`
 
-  const app = await buildApp({
-    connectionString: BASE_CONNECTION_STRING,
-    singleTenant: true,
-    defaultAppId: appIdStr,
-    enablePoller: false,
-  })
+  process.env.DATABASE_URL = BASE_CONNECTION_STRING
+  process.env.PLT_WORLD_APP_ID = appIdStr
+  process.env.WF_ENABLE_POLLER = 'false'
 
+  const app = Fastify({ logger: false })
+  await app.register(autoload, { dir: join(__dirname, '..', 'plugins') })
   await app.ready()
 
   return {

--- a/packages/workflow/test/single-tenant.test.ts
+++ b/packages/workflow/test/single-tenant.test.ts
@@ -1,24 +1,25 @@
 import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildApp } from '../src/app.ts'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Fastify from 'fastify'
+import autoload from '@fastify/autoload'
 import type { FastifyInstance } from 'fastify'
 
-const CONNECTION_STRING = process.env.DATABASE_URL || 'postgresql://wf:wf@localhost:5434/workflow'
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 let app: FastifyInstance
 
 before(async () => {
-  app = await buildApp({
-    connectionString: CONNECTION_STRING,
-    singleTenant: true,
-    defaultAppId: 'single-tenant-test',
-    enablePoller: false,
-  })
+  process.env.PLT_WORLD_APP_ID = 'single-tenant-test'
+  process.env.WF_ENABLE_POLLER = 'false'
+
+  app = Fastify({ logger: false })
+  await app.register(autoload, { dir: join(__dirname, '..', 'plugins') })
   await app.ready()
 })
 
 after(async () => {
-  // Clean up
   const result = await app.pg.query(
     'SELECT id FROM workflow_applications WHERE app_id = $1',
     ['single-tenant-test']
@@ -45,24 +46,7 @@ test('default app is auto-provisioned', async () => {
   assert.equal(result.rows[0].app_id, 'single-tenant-test')
 })
 
-test('GET /status works without auth header', async () => {
-  const response = await app.inject({
-    method: 'GET',
-    url: '/status',
-  })
-  assert.equal(response.statusCode, 200)
-})
-
-test('GET /ready works without auth header', async () => {
-  const response = await app.inject({
-    method: 'GET',
-    url: '/ready',
-  })
-  assert.equal(response.statusCode, 200)
-})
-
 test('POST /api/v1/apps/:appId/events works without auth header', async () => {
-  // First create a run
   const runResponse = await app.inject({
     method: 'POST',
     url: '/api/v1/apps/single-tenant-test/events',

--- a/packages/workflow/watt.json
+++ b/packages/workflow/watt.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schemas.platformatic.dev/@platformatic/service/3.40.0.json",
+  "server": {
+    "hostname": "{HOST}",
+    "port": "{PORT}"
+  },
+  "runtime": {
+    "metrics": true
+  },
+  "plugins": {
+    "paths": ["./plugins"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: link:../packages/world
       next:
         specifier: ^15.3.0
-        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -31,7 +31,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       workflow:
         specifier: 4.2.0-beta.67
-        version: 4.2.0-beta.67(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        version: 4.2.0-beta.67(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: ^22.15.0
@@ -51,12 +51,24 @@ importers:
 
   packages/workflow:
     dependencies:
+      '@fastify/autoload':
+        specifier: ^6.0.3
+        version: 6.3.1
       '@fastify/error':
         specifier: ^4.1.0
         version: 4.2.0
+      '@platformatic/leader':
+        specifier: ^0.1.0
+        version: 0.1.1
+      '@platformatic/service':
+        specifier: ^3.40.0
+        version: 3.41.0(typescript@5.9.3)
       fastify:
         specifier: ^5.3.3
         version: 5.8.1
+      fastify-plugin:
+        specifier: ^5.1.0
+        version: 5.1.0
       pg:
         specifier: ^8.16.0
         version: 8.20.0
@@ -66,6 +78,9 @@ importers:
       undici:
         specifier: ^7.22.0
         version: 7.22.0
+      wattpm:
+        specifier: ^3.40.0
+        version: 3.41.0
     devDependencies:
       '@types/node':
         specifier: ^22.15.0
@@ -168,6 +183,23 @@ packages:
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
     engines: {node: '>=18.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
 
   '@borewit/text-codec@0.2.1':
     resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
@@ -399,8 +431,26 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
+  '@fastify/accepts@5.0.4':
+    resolution: {integrity: sha512-XKtvD77ZLQ/4G5r1WhPua5+rTctt16DF4XUMBQuP8KM/Ic431GhfqjJoYvwS4aDaUhoRTiU9DGFaMZ3TRM6ctg==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/autoload@6.3.1':
+    resolution: {integrity: sha512-0fsG+lO3m5yEZVjXKpltCe+2eHhM6rfAPQhvlGUgLUFTw/N2wA9WqPTObMtrF3oUCUrxbSDv60HlUIoh+aFM1A==}
+
+  '@fastify/basic-auth@6.2.0':
+    resolution: {integrity: sha512-Ao9Jf8TyW8v7p3CPy++c+E3qcCDeWfAlSIfFo0CsKrfvm81i0OCpnobIMwaSSkg/At0rzsLzbJPDWrgNru0G1w==}
+
+  '@fastify/cors@10.1.0':
+    resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
+
+  '@fastify/deepmerge@2.0.2':
+    resolution: {integrity: sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -411,11 +461,46 @@ packages:
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
 
+  '@fastify/merge-json-schemas@0.1.1':
+    resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
+
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@8.3.0':
+    resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
+
+  '@fastify/static@9.0.0':
+    resolution: {integrity: sha512-r64H8Woe/vfilg5RTy7lwWlE8ZZcTrc3kebYFMEUBrMqlydhQyoiExQXdYAy2REVpST/G35+stAM8WYp1WGmMA==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
+
+  '@fastify/under-pressure@9.0.3':
+    resolution: {integrity: sha512-uWzyFn9ThgGgynxyoX/kqgLtPtNBXXvQgN3U8fSRPNBS1y5mEZC/uCBRx03hXm9PDsQwTGN7qt83ItsHVQ0L4A==}
+
+  '@fastify/websocket@11.2.0':
+    resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -435,6 +520,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -609,8 +697,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
 
   '@mjackson/node-fetch-server@0.2.0':
@@ -832,8 +927,369 @@ packages:
     resolution: {integrity: sha512-5N/X/FzlJaYfpaHwDC0YHzOzKDWa41s9t+4FpCDu4f9OMReds4JeNBaaWk9rlIzdKjh2M6AC5Q18ORfECRkHGA==}
     engines: {node: '>=18.0.0'}
 
+  '@opentelemetry/api-logs@0.203.0':
+    resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api-logs@0.206.0':
+    resolution: {integrity: sha512-yIVDu9jX//nV5wSMLZLdHdb1SKHIMj9k+wQVFtln5Flcgdldz9BkHtavvExQiJqBZg2OpEEJEZmzQazYztdz2A==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.0.1':
+    resolution: {integrity: sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.0.1':
+    resolution: {integrity: sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.1.0':
+    resolution: {integrity: sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.0':
+    resolution: {integrity: sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.203.0':
+    resolution: {integrity: sha512-g/2Y2noc/l96zmM+g0LdeuyYKINyBwN6FJySoU15LHPLcMN/1a0wNk2SegwKcxrRdE7Xsm7fkIR5n6XFe3QpPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.206.0':
+    resolution: {integrity: sha512-kJKxKBaGwqWop95d6tcluz260IWwIgOG0BH8oVm6429tg8LxY2PJb7Om8d5s+5vOFM8DkUYCnIpn9d/13/RcKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.203.0':
+    resolution: {integrity: sha512-s0hys1ljqlMTbXx2XiplmMJg9wG570Z5lH7wMvrZX6lcODI56sG4HL03jklF63tBeyNwK2RV1/ntXGo3HgG4Qw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.206.0':
+    resolution: {integrity: sha512-VWcHEnS+1kN+sQTAdCgSn2anqHPxY1/e52fhpe2mcSnEaXI1srFf3RU5DAu7hzQO6T9DPQzOKG8kc76vCtyYDw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.203.0':
+    resolution: {integrity: sha512-nl/7S91MXn5R1aIzoWtMKGvqxgJgepB/sH9qW0rZvZtabnsjbf8OQ1uSx3yogtvLr0GzwD596nQKz2fV7q2RBw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.206.0':
+    resolution: {integrity: sha512-CsYNXJwkn1qCXJGE+/JvvYucAjL8rpaxa2hnl+tDP6M5E0O3UVa8zG4ZUEebjr5J5Nc32egvslEZx5rgNOp3lQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.203.0':
+    resolution: {integrity: sha512-FCCj9nVZpumPQSEI57jRAA89hQQgONuoC35Lt+rayWY/mzCAc6BQT7RFyFaZKJ2B7IQ8kYjOCPsF/HGFWjdQkQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.203.0':
+    resolution: {integrity: sha512-HFSW10y8lY6BTZecGNpV3GpoSy7eaO0Z6GATwZasnT4bEsILp8UJXNG5OmEsz4SdwCSYvyCbTJdNbZP3/8LGCQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.203.0':
+    resolution: {integrity: sha512-OZnhyd9npU7QbyuHXFEPVm3LnjZYifuKpT3kTnF84mXeEQ84pJJZgyLBpU4FSkSwUkt/zbMyNAI7y5+jYTWGIg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.203.0':
+    resolution: {integrity: sha512-2jLuNuw5m4sUj/SncDf/mFPabUxMZmmYetx5RKIMIQyPnl6G6ooFzfeE8aXNRf8YD1ZXNlCnRPcISxjveGJHNg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.203.0':
+    resolution: {integrity: sha512-322coOTf81bm6cAA8+ML6A+m4r2xTCdmAZzGNTboPXRzhwPt4JEmovsFAs+grpdarObd68msOJ9FfH3jxM6wqA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.203.0':
+    resolution: {integrity: sha512-ZDiaswNYo0yq/cy1bBLJFe691izEJ6IgNmkjm4C6kE9ub/OMQqDXORx2D2j8fzTBTxONyzusbaZlqtfmyqURPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.203.0':
+    resolution: {integrity: sha512-1xwNTJ86L0aJmWRwENCJlH4LULMG2sOXWIVw+Szta4fkqKVY50Eo4HoVKKq6U9QEytrWCr8+zjw0q/ZOeXpcAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.0.1':
+    resolution: {integrity: sha512-a9eeyHIipfdxzCfc2XPrE+/TI3wmrZUDFtG2RRXHSbZZULAny7SyybSvaDvS77a7iib5MPiAvluwVvbGTsHxsw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/exporter-zipkin@2.6.0':
+    resolution: {integrity: sha512-AFP77OQMLfw/Jzh6WT2PtrywstNjdoyT9t9lYrYdk1s4igsvnMZ8DkZKCwxsItC01D+4Lydgrb+Wy0bAvpp8xg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-http@0.203.0':
+    resolution: {integrity: sha512-y3uQAcCOAwnO6vEuNVocmpVzG3PER6/YZqbPbbffDdJ9te5NkHEkfSMNzlC3+v7KlE+WinPGc3N7MR30G1HY2g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.14.0':
+    resolution: {integrity: sha512-2HN+7ztxAReXuxzrtA3WboAKlfP5OsPA57KQn2AdYZbJ3zeRPcLXyW4uO/jpLE6PLm0QRtmeGCmfYpqRlwgSwg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.203.0':
+    resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.203.0':
+    resolution: {integrity: sha512-Wbxf7k+87KyvxFr5D7uOiSq/vHXWommvdnNE7vECO3tAhsA2GfOlpWINCMWUEPdHZ7tCXxw6Epp3vgx3jU7llQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.206.0':
+    resolution: {integrity: sha512-Rv54oSNKMHYS5hv+H5EGksfBUtvPQWFTK+Dk6MjJun9tOijCsFJrhRFvAqg5d67TWSMn+ZQYRKIeXh5oLVrpAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.203.0':
+    resolution: {integrity: sha512-te0Ze1ueJF+N/UOFl5jElJW4U0pZXQ8QklgSfJ2linHN0JJsuaHG8IabEUi2iqxY8ZBDlSiz1Trfv5JcjWWWwQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.206.0':
+    resolution: {integrity: sha512-IA8EDbrB8OKtidMqErBY8sUc9mh03LOXuNPwp4/rdPrxSt45g1gBuZMovRXdEWfRyKKbF2E7MdipT2m11bs6SQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.203.0':
+    resolution: {integrity: sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.206.0':
+    resolution: {integrity: sha512-Li2Cik1WnmNbU2mmTnw7DxvRiXhMcnAuTfAclP8y/zy7h5+GrLDpTZ+Z0XUs+Q3MLkb/h3ry4uFrC/z+2a6X7g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.0.1':
+    resolution: {integrity: sha512-Hc09CaQ8Tf5AGLmf449H726uRoBNGPBL4bjr7AnnUpzWMvhdn61F78z9qb6IqB737TffBsokGAK1XykFEZ1igw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.0.1':
+    resolution: {integrity: sha512-7PMdPBmGVH2eQNb/AtSJizQNgeNTfh6jQFqys6lfhd6P4r+m/nTh3gKPPpaCXVdRQ+z93vfKk+4UGty390283w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.0.1':
+    resolution: {integrity: sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.1.0':
+    resolution: {integrity: sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.6.0':
+    resolution: {integrity: sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.203.0':
+    resolution: {integrity: sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.206.0':
+    resolution: {integrity: sha512-SQ2yTmqe4Mw9RI3a/glVkfjWPsXh6LySvnljXubiZq4zu+UP8NMJt2j82ZsYb+KpD7Eu+/41/7qlJnjdeVjz7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.0.1':
+    resolution: {integrity: sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.1.0':
+    resolution: {integrity: sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.203.0':
+    resolution: {integrity: sha512-zRMvrZGhGVMvAbbjiNQW3eKzW/073dlrSiAKPVWmkoQzah9wfynpVPeL55f9fVIm0GaBxTLcPeukWGy0/Wj7KQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.0.1':
+    resolution: {integrity: sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.1.0':
+    resolution: {integrity: sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.6.0':
+    resolution: {integrity: sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.0.1':
+    resolution: {integrity: sha512-UhdbPF19pMpBtCWYP5lHbTogLWx9N0EBxtdagvkn5YtsAnCBZzL7SjktG+ZmupRgifsHMjwUaCCaVmqGfSADmA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.36.0':
+    resolution: {integrity: sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@platformatic/basic@3.41.0':
+    resolution: {integrity: sha512-6zr42yzT/WogtVwp0y34WfHwYGGOWIfpuSgqQkcWc187saLkQUcGwHbxikeIG3I1/S+SbVE6hef4VBmgYDYUAA==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/control@3.41.0':
+    resolution: {integrity: sha512-ytNHiVHu1dFqjPhu0oBUxH7s/c0KdLa6Y3WuqOIj/LxpSO0TkTXgN1UEQ+yDTQRkisvb2COnfwXDTcDrKCHCYQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/foundation@3.41.0':
+    resolution: {integrity: sha512-3KRd2DzZPGnq1crArmpv/2ukUyDwua0BG0SK0wmJzr6ZjbGUeQGHZ3bTzGiW/CRURZnheMawyWzLRKZ3BEIBnw==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/generators@3.41.0':
+    resolution: {integrity: sha512-3wNIX0LXmkS34VofrX+NLkW0zCJAHLDTVPG6oQnTpsC2kJQBz9DMvYgNZPIA1oNNSuYoQL0+V4+Qj4AV1gzyyA==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/http-metrics@0.3.0':
+    resolution: {integrity: sha512-e+wQJDCd9v7yKeV4u30ibAe5uGB14k+jDw1w9FqsM3tDgFY0UEHb24hJR9j2bVa6091e+ppGy3L4LhyUR92M0w==}
+
+  '@platformatic/itc@3.41.0':
+    resolution: {integrity: sha512-wrGVupCHmvLXRl/7A0I+T0Nrc2avUqvYXeg3mK3UpbA9QoR9bki9NOHtznqs7nC97HPDXiDp1+bfldT4GvVu/g==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/leader@0.1.1':
+    resolution: {integrity: sha512-BHp8sHN8x/HGjj9G6Dt6Dc6f/zW02oQ9CMxXGsOyTMbs5HjQ9xJ3eGwKJG5KJOBja7/oGglLWh8MY692egWO/A==}
+    engines: {node: '>=22.0.0'}
+
+  '@platformatic/metrics@3.41.0':
+    resolution: {integrity: sha512-m2NPVOhxmhKV8F2K+vR0qvPky+o8p6UhkyE8Z0+FH19p5gKNH/FHj9u3c0tLkXZsCIqM2hEgvC/M79QTUgQClw==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/prom-client@1.0.0':
+    resolution: {integrity: sha512-O7NfmdBWAm1QJ0LMrtcyCSgWmA+FQEiCyRqvouccmyAuydwLxLdmhcTTW3sEmO5f7bRfXpUVVgTtnFbIqEiHyw==}
+    engines: {node: ^20 || ^22 || >=24}
+
+  '@platformatic/promotel@0.1.0':
+    resolution: {integrity: sha512-PpbXGiGef+zW9LAbD3JP1ehTDhRXXcrBz+cg1fd5kZamMqqf3leXSjOBlagqxaMk8e1M1GggnmB4RxGBvoAcGQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@platformatic/runtime@3.41.0':
+    resolution: {integrity: sha512-WGf/+D2T2FKupe0788ZJeyX1sNOnEVzYrDkCK7KqnSYDFSkcQ3vefMszFWJXFxlTxsVHyMGm1MkpzvFiDkNpRQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/scalar-theme@3.41.0':
+    resolution: {integrity: sha512-HAjtV/hkytH/pZy05rKIJBVFxrLxg/vA01RIGOaQlny8R+Es0Q6E1nz2qUum0uhzp6m6MEXKcEJHbjxyJKWYkQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/service@3.41.0':
+    resolution: {integrity: sha512-9BG+J7nujWPpoHTgGQ+QYSuqCgBhtpIrDcjSuALbquXbZBwgZzeNfckofSZ5HPXH2hcgYHpXUV17a8X1cBiftA==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/telemetry@3.41.0':
+    resolution: {integrity: sha512-c7TVD5/81eAcSzIu+gCg3DcmjbJzi9SJZWGl7G9VrAuIb/lGzab742VBqilM4IVdPLFvNb8oz4Wf54455scVHw==}
+    engines: {node: '>=22.19.0'}
+
+  '@platformatic/undici-cache-memory@0.8.4':
+    resolution: {integrity: sha512-/JVfPhyUW0GQkmr5lGAGOgh0lpJbTcLG8VB2uNqgNgH1fhPPFAM0l4pLSyeDzpTj2r/GJPLqhzvCgangnSHfoQ==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@react-router/node@7.13.1':
     resolution: {integrity: sha512-IWPPf+Q3nJ6q4bwyTf5leeGUfg8GAxSN1RKj5wp9SK915zKK+1u4TCOfOmr8hmC6IW1fcjKV0WChkM0HkReIiw==}
@@ -845,9 +1301,44 @@ packages:
       typescript:
         optional: true
 
+  '@scalar/core@0.3.14':
+    resolution: {integrity: sha512-Fjgscu148WY1g28VNVZikQxGX8iwronPttIoCf7ayausnVMWX6s6wOZm0D3StNbxqMl2js8FQ/s0GlfCAG6XEg==}
+    engines: {node: '>=20'}
+
+  '@scalar/fastify-api-reference@1.34.6':
+    resolution: {integrity: sha512-s3cMsbPW3vw+5m3jWBcMtnPdrVBNrlDZK2CV2PPrhQNf3Gcs/xi5mS/42hffJiLmyeIJ+6C/Lzuph1WPOxaBPw==}
+    engines: {node: '>=20'}
+
+  '@scalar/helpers@0.0.8':
+    resolution: {integrity: sha512-9A1CxL3jV7Kl9wGu86/cR/wiJN6J+3tK4WuW3252s2gF+upXsgQRx9WLhFF3xifOP1irIGusitZBiojiKmUSVg==}
+    engines: {node: '>=20'}
+
+  '@scalar/json-magic@0.3.1':
+    resolution: {integrity: sha512-vQvl4TckiMT8Txo6S82ETJ4OI+K6iSxLZsjPaq4cEqY+9zVfmIMALFGPj/X5BB8tU3FdluV2yEa8LswsMQ68IA==}
+    engines: {node: '>=20'}
+
+  '@scalar/openapi-parser@0.20.1':
+    resolution: {integrity: sha512-rxtuBQ90YsUEDefWU3GAEmvjYr1CvGO6nkDVzbjmWv2aPB3mtK80bCRBgQGTdIdW5XQEWAAmflSKEhcj2Xo5QA==}
+    engines: {node: '>=20'}
+
+  '@scalar/openapi-types@0.3.7':
+    resolution: {integrity: sha512-QHSvHBVDze3+dUwAhIGq6l1iOev4jdoqdBK7QpfeN1Q4h+6qpVEw3EEqBiH0AXUSh/iWwObBv4uMgfIx0aNZ5g==}
+    engines: {node: '>=20'}
+
+  '@scalar/types@0.2.13':
+    resolution: {integrity: sha512-rO6KGMJqOsBnN/2R4fErMFLpRSPVJElni+HABDpf+ZlLJp2lvxuPn0IXLumK5ytfplUH9iqKgSXjndnZfxSYLQ==}
+    engines: {node: '>=20'}
+
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@smithy/abort-controller@4.2.11':
     resolution: {integrity: sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==}
@@ -1147,6 +1638,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1158,6 +1652,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
@@ -1237,6 +1734,38 @@ packages:
   '@vercel/queue@0.1.1':
     resolution: {integrity: sha512-ozO0tSBXUYN4gUkK65GbcqgxpC55qaaiY9MzNuXW4cvOSJ5nCkcgO+DQXcfyfL7h+0uIC5HTcP0mPvQ3dW3EhQ==}
     engines: {node: '>=20.0.0'}
+
+  '@vue/compiler-core@3.5.30':
+    resolution: {integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==}
+
+  '@vue/compiler-dom@3.5.30':
+    resolution: {integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==}
+
+  '@vue/compiler-sfc@3.5.30':
+    resolution: {integrity: sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==}
+
+  '@vue/compiler-ssr@3.5.30':
+    resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
+
+  '@vue/reactivity@3.5.30':
+    resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
+
+  '@vue/runtime-core@3.5.30':
+    resolution: {integrity: sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==}
+
+  '@vue/runtime-dom@3.5.30':
+    resolution: {integrity: sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==}
+
+  '@vue/server-renderer@3.5.30':
+    resolution: {integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==}
+    peerDependencies:
+      vue: 3.5.30
+
+  '@vue/shared@3.5.30':
+    resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
+
+  '@watchable/unpromise@1.0.2':
+    resolution: {integrity: sha512-yGCKYzCrAfJQ9yzm76r1bl4WUIWyqmh4vqidXn5LyOfPbgdiZrKOyvW2ivqIvtmsRVb7u3ModEpc4q901VRgXw==}
 
   '@workflow/astro@4.0.0-beta.41':
     resolution: {integrity: sha512-CHpZduft3RFjlpsbAidIhHrGifYtj/y4ueb/+BqWLagt/Vlye9lTn/RPOvfJLcXL/bkn8fo+22giIwZCCGK1/A==}
@@ -1376,12 +1905,21 @@ packages:
     resolution: {integrity: sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==}
     engines: {node: ^14.14.0 || >=16.0.0}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1392,6 +1930,18 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1474,6 +2024,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1564,9 +2118,19 @@ packages:
     resolution: {integrity: sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==}
     engines: {node: '>=12'}
 
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
+
+  bl@5.1.0:
+    resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
+
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  boring-name-generator@1.0.3:
+    resolution: {integrity: sha512-1wEo1pNahY9js7Vkp1RQa/VWdWrXYJnVAmsHV3Pw/0YzspjABLw7dcekjukOMTIYWr8ir/aG0GX1eoEkYhpnUg==}
+    hasBin: true
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -1590,6 +2154,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
@@ -1657,6 +2224,12 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case-all@2.1.0:
+    resolution: {integrity: sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -1671,6 +2244,13 @@ packages:
   citty@0.2.1:
     resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
   clean-stack@3.0.1:
     resolution: {integrity: sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==}
     engines: {node: '>=10'}
@@ -1679,9 +2259,17 @@ packages:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
 
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
+
+  cli-progress@3.12.0:
+    resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
+    engines: {node: '>=4'}
 
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
@@ -1690,9 +2278,19 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  close-with-grace@2.5.0:
+    resolution: {integrity: sha512-MewUtZQU6N4YVHIne63zGtjIQzTINgr6lQp2Y0CutaCw2FsdYahW57dH1Wdz+aV5ipbBzEBZD5znwX2NooS+IA==}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1700,6 +2298,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
@@ -1722,9 +2323,16 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  console-table-printer@2.15.0:
+    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -1740,6 +2348,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cron@4.4.0:
+    resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
+    engines: {node: '>=18.x'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1762,6 +2374,13 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+
+  debounce@2.2.0:
+    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
+    engines: {node: '>=18'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -1859,6 +2478,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   easy-table@1.2.0:
     resolution: {integrity: sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==}
 
@@ -1880,9 +2502,19 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  env-schema@7.0.0:
+    resolution: {integrity: sha512-b8rdAwdFpekDxNAUNuT6KbV/QEX/pTBs0gjehEPmBUUteh9zBDm9zxFSQt55D29odo3rJt4feoWRqn4U/tzicw==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1927,6 +2559,10 @@ packages:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2007,6 +2643,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2018,12 +2657,24 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -2043,6 +2694,9 @@ packages:
     resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
     engines: {node: '>=4'}
 
+  fast-copy@4.0.2:
+    resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
@@ -2052,8 +2706,14 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-json-stringify@5.16.1:
+    resolution: {integrity: sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==}
 
   fast-json-stringify@6.3.0:
     resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
@@ -2067,6 +2727,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-uri@2.4.0:
+    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2077,8 +2740,21 @@ packages:
     resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
     hasBin: true
 
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
+  fastify-plugin@4.5.1:
+    resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
   fastify@5.8.1:
     resolution: {integrity: sha512-y0kicFvvn7CYWoPOVLOcvn4YyKQz03DIY7UxmyOy21/J8eXm09R+tmb+tVDBW5h+pja30cHI5dqUcSlvY86V2A==}
+
+  fastparallel@2.4.1:
+    resolution: {integrity: sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2094,6 +2770,10 @@ packages:
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2161,6 +2841,9 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -2183,9 +2866,16 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -2207,6 +2897,10 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -2217,6 +2911,9 @@ packages:
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2230,6 +2927,10 @@ packages:
     engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -2260,6 +2961,15 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql-jit@0.8.7:
+    resolution: {integrity: sha512-KGzCrsxQPfEiXOUIJCexWKiWF6ycjO89kAO6SdO8OWRGwYXbG0hsLuTnbFfMq0gj7d7/ib/Gh7jtst7FHZEEjw==}
+    peerDependencies:
+      graphql: '>=15'
+
+  graphql@16.13.1:
+    resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2292,6 +3002,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -2306,6 +3019,13 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
+  hyperid@3.3.0:
+    resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -2325,6 +3045,9 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2439,6 +3162,13 @@ packages:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2454,6 +3184,10 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -2526,6 +3260,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2536,8 +3274,15 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-ref-resolver@1.0.1:
+    resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
+
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2556,6 +3301,10 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -2573,6 +3322,14 @@ packages:
 
   knitwork@1.3.0:
     resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
+  leven@4.1.0:
+    resolution: {integrity: sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2601,12 +3358,34 @@ packages:
     resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
     engines: {node: '>=20'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+
+  log-symbols@5.1.0:
+    resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
+    engines: {node: '>=12'}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2620,6 +3399,10 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2630,6 +3413,12 @@ packages:
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
+
+  mercurius@16.8.0:
+    resolution: {integrity: sha512-b0ZxtmqgqH8GBvXxs5wITLNZdTOVd7FzkuvUkUgg0waEM1UD8buDcl0RVrqH745WOpGRqID2ltWRVfNeLIXh5w==}
+    engines: {node: ^20.9.0 || >=22.0.0}
+    peerDependencies:
+      graphql: ^16.0.0
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -2656,6 +3445,11 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
     hasBin: true
 
   mimic-fn@2.1.0:
@@ -2689,6 +3483,9 @@ packages:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2704,15 +3501,33 @@ packages:
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
+  mnemonist@0.40.0:
+    resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  mqemitter@7.1.0:
+    resolution: {integrity: sha512-GnBDNz3lxmllW201ne0mrmdy5tPOTnc79jjVcsfUa2LG2pUGeyGWVeiae6ZysfC/64XrYOqCKRAQYrB7pGyBVQ==}
+    engines: {node: '>=20'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  my-ua-parser@2.0.4:
+    resolution: {integrity: sha512-lhPyjoce3SRNXqgozoVti8XWC6oWY/rMcXljvov9IAgHKj2ZTU3dR5iQ7jLrIj02xD4Ggn6doTi7K2pnSbjzeg==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   nanoid@5.1.6:
@@ -2774,6 +3589,10 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
     engines: {node: '>=18'}
@@ -2807,6 +3626,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obliterator@2.0.5:
+    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -2817,6 +3639,9 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -2834,9 +3659,16 @@ packages:
     resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
     engines: {node: '>=12'}
 
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@6.3.1:
+    resolution: {integrity: sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
@@ -2845,6 +3677,9 @@ packages:
   os-paths@4.4.0:
     resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
     engines: {node: '>= 6.0'}
+
+  otlp-logger@1.1.13:
+    resolution: {integrity: sha512-r53tPnMLprtQSMOJUkj4Az4tR8NL+U+8C7M8BV1ZA9y7cDfAbWQp2mRL/eYS/O786oAi9KnN9hKsZ5cFKNchKw==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -2870,12 +3705,20 @@ packages:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2892,6 +3735,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -2960,14 +3807,30 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-opentelemetry-transport@2.0.0:
+    resolution: {integrity: sha512-tWoq02WEtnCWfr63Co1n0sGlDpkBz2YUovSAsSBv/+jwKUIn/PjxwRileGViKrH/K3e+oc71nGl6yUdgQlrVkg==}
+    peerDependencies:
+      pino: ^10.0.0
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
 
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   piscina@4.9.2:
@@ -2985,6 +3848,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgrator@8.0.0:
@@ -3011,22 +3878,45 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qlobber@8.0.1:
+    resolution: {integrity: sha512-O+Wd1chXj5YE1DwmD+ae0bXiSLehmnS3czlC1R9FL/Nt/3q8uMS1bIHmg2lJfCoiimCxClWM8AAuJrF0EvNiog==}
+    engines: {node: '>= 16'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -3038,6 +3928,10 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quick-lru@7.3.0:
+    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
+    engines: {node: '>=18'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -3075,6 +3969,14 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -3098,9 +4000,17 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -3112,6 +4022,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.11:
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   resolve@2.0.0-next.6:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
@@ -3120,6 +4035,10 @@ packages:
   responselike@3.0.0:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -3183,6 +4102,9 @@ packages:
   seek-bzip@2.0.0:
     resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
     hasBin: true
+
+  semgrator@0.3.0:
+    resolution: {integrity: sha512-TIMBco3kY4+jNk+uiSpbW6dwZ2kCnLPEcPbxIpcDV9UcVL0egYsiQIhljZU5meLTYjNRqFyZ+JwdsfC4ryrUCA==}
 
   semver-regex@4.0.5:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
@@ -3262,9 +4184,19 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+
+  single-user-cache@2.1.0:
+    resolution: {integrity: sha512-Wmu+uIEkabMoQPpJTOYhEsE6h/XjnjIhtuB1+tynxeO/hQxwQD0hIDq/ad65P1Tw9wt9f5SKnUe+63m6TMB4Uw==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -3289,9 +4221,16 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sponge-case@2.0.3:
+    resolution: {integrity: sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  stdin-discarder@0.1.0:
+    resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -3300,6 +4239,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
@@ -3331,6 +4273,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3346,9 +4291,17 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
@@ -3390,12 +4343,28 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swap-case@3.0.3:
+    resolution: {integrity: sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==}
+
+  systeminformation@5.31.4:
+    resolution: {integrity: sha512-lZppDyQx91VdS5zJvAyGkmwe+Mq6xY978BDUG2wRkWE+jkmUF5ti8cvOovFQoN5bvSFKCXVkyKEaU5ec3SJiRg==}
+    engines: {node: '>=8.0.0'}
+    os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
+    hasBin: true
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -3407,12 +4376,19 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiny-lru@11.4.7:
+    resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
+    engines: {node: '>=12'}
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
@@ -3421,6 +4397,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  title-case@3.0.3:
+    resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
 
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
@@ -3517,8 +4496,19 @@ packages:
   unctx@2.5.0:
     resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
 
+  undici-thread-interceptor@1.3.1:
+    resolution: {integrity: sha512-s/TUkGeVj+C4Rr3Vsy84Kewj97m2QBNx6IjMGM1nzfoKWqNlcLqtFQCbXQjobRJQKi3u9Hc796/YvJIv7W7qWQ==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.23.0:
+    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+    engines: {node: '>=18.17'}
+
+  undici@7.18.2:
+    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+    engines: {node: '>=20.18.1'}
 
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
@@ -3551,17 +4541,40 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid-parse@1.1.0:
+    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vue@3.5.30:
+    resolution: {integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
+
+  wattpm@3.41.0:
+    resolution: {integrity: sha512-l1L7o7GyNAryPclxoiEjdMwlfuDGGxtrrJqUVKsrNqUuis9Ux39V4byt1RL+UbmJesZV8L5cSW4HppdSO+h/Bw==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -3622,6 +4635,21 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
@@ -3638,6 +4666,28 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
   yauzl@3.2.0:
     resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
     engines: {node: '>=12'}
@@ -3649,6 +4699,13 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
@@ -3834,6 +4891,19 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.3': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
   '@borewit/text-codec@0.2.1': {}
 
   '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
@@ -3983,11 +5053,32 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
+  '@fastify/accepts@5.0.4':
+    dependencies:
+      accepts: 1.3.8
+      fastify-plugin: 5.1.0
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
+
+  '@fastify/autoload@6.3.1': {}
+
+  '@fastify/basic-auth@6.2.0':
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.1.0
+
+  '@fastify/cors@10.1.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      mnemonist: 0.40.0
+
+  '@fastify/deepmerge@2.0.2': {}
 
   '@fastify/error@4.2.0': {}
 
@@ -3997,6 +5088,10 @@ snapshots:
 
   '@fastify/forwarded@3.0.1': {}
 
+  '@fastify/merge-json-schemas@0.1.1':
+    dependencies:
+      fast-deep-equal: 3.1.3
+
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
@@ -4005,6 +5100,72 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@8.3.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 0.5.4
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 11.1.0
+
+  '@fastify/static@9.0.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.0.1
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/swagger@9.7.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fastify/under-pressure@9.0.3':
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.1.0
+
+  '@fastify/websocket@11.2.0':
+    dependencies:
+      duplexify: 4.1.3
+      fastify-plugin: 5.1.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.13.1)':
+    dependencies:
+      graphql: 16.13.1
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
 
   '@humanfs/core@0.19.1': {}
 
@@ -4018,6 +5179,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iarna/toml@2.2.5': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -4137,7 +5300,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@lukeed/csprng@1.1.0': {}
+
+  '@lukeed/ms@2.0.2': {}
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
@@ -4317,7 +5484,605 @@ snapshots:
     dependencies:
       '@oclif/core': 4.8.1
 
+  '@opentelemetry/api-logs@0.203.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api-logs@0.206.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.206.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.206.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.206.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.206.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.206.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.206.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.206.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-prometheus@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-zipkin@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/exporter-zipkin@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/instrumentation-http@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.14.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-exporter-base@0.206.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.206.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.206.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.206.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/otlp-transformer@0.206.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.206.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/propagator-b3@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/resources@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/sdk-logs@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-logs@0.206.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.206.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-node@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-prometheus': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+
+  '@opentelemetry/sdk-trace-node@2.0.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/semantic-conventions@1.36.0': {}
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
   '@pinojs/redact@0.4.0': {}
+
+  '@platformatic/basic@3.41.0':
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@platformatic/foundation': 3.41.0
+      '@platformatic/itc': 3.41.0
+      '@platformatic/metrics': 3.41.0
+      '@platformatic/telemetry': 3.41.0
+      execa: 9.6.1
+      fast-json-patch: 3.1.1
+      pino: 9.14.0
+      pino-abstract-transport: 2.0.0
+      semver: 7.7.4
+      split2: 4.2.0
+      undici: 7.22.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@platformatic/control@3.41.0':
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@platformatic/foundation': 3.41.0
+      help-me: 5.0.0
+      pino: 9.14.0
+      pino-pretty: 13.1.3
+      table: 6.9.0
+      undici: 7.22.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@platformatic/foundation@3.41.0':
+    dependencies:
+      '@fastify/deepmerge': 2.0.2
+      '@fastify/error': 4.2.0
+      '@iarna/toml': 2.2.5
+      '@watchable/unpromise': 1.0.2
+      ajv: 8.18.0
+      boring-name-generator: 1.0.3
+      colorette: 2.0.20
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-json-patch: 3.1.1
+      json5: 2.2.3
+      leven: 3.1.0
+      pino: 9.14.0
+      pino-pretty: 13.1.3
+      semver: 7.7.4
+      undici: 7.18.2
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@platformatic/generators@3.41.0':
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@platformatic/foundation': 3.41.0
+      change-case-all: 2.1.0
+      execa: 9.6.1
+      fastify: 5.8.1
+      pino: 9.14.0
+      undici: 7.22.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@platformatic/http-metrics@0.3.0':
+    dependencies:
+      '@platformatic/prom-client': 1.0.0
+
+  '@platformatic/itc@3.41.0':
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@watchable/unpromise': 1.0.2
+
+  '@platformatic/leader@0.1.1':
+    dependencies:
+      pg: 8.20.0
+      pino: 10.3.1
+    transitivePeerDependencies:
+      - pg-native
+
+  '@platformatic/metrics@3.41.0':
+    dependencies:
+      '@platformatic/http-metrics': 0.3.0
+      '@platformatic/prom-client': 1.0.0
+      '@platformatic/promotel': 0.1.0
+
+  '@platformatic/prom-client@1.0.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@platformatic/promotel@0.1.0':
+    dependencies:
+      long: 5.3.2
+      prom-client: 15.1.3
+      protobufjs: 7.5.4
+      undici: 6.23.0
+
+  '@platformatic/runtime@3.41.0':
+    dependencies:
+      '@fastify/accepts': 5.0.4
+      '@fastify/basic-auth': 6.2.0
+      '@fastify/error': 4.2.0
+      '@fastify/websocket': 11.2.0
+      '@opentelemetry/api': 1.9.0
+      '@platformatic/basic': 3.41.0
+      '@platformatic/foundation': 3.41.0
+      '@platformatic/generators': 3.41.0
+      '@platformatic/itc': 3.41.0
+      '@platformatic/metrics': 3.41.0
+      '@platformatic/prom-client': 1.0.0
+      '@platformatic/telemetry': 3.41.0
+      '@platformatic/undici-cache-memory': 0.8.4
+      '@watchable/unpromise': 1.0.2
+      change-case-all: 2.1.0
+      close-with-grace: 2.5.0
+      colorette: 2.0.20
+      cron: 4.4.0
+      debounce: 2.2.0
+      fastest-levenshtein: 1.0.16
+      fastify: 5.8.1
+      graphql: 16.13.1
+      help-me: 5.0.0
+      minimist: 1.2.8
+      pino: 9.14.0
+      pino-opentelemetry-transport: 2.0.0(@opentelemetry/api@1.9.0)(pino@9.14.0)
+      pino-pretty: 13.1.3
+      semgrator: 0.3.0
+      sonic-boom: 4.2.1
+      systeminformation: 5.31.4
+      undici: 7.22.0
+      undici-thread-interceptor: 1.3.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@platformatic/scalar-theme@3.41.0': {}
+
+  '@platformatic/service@3.41.0(typescript@5.9.3)':
+    dependencies:
+      '@fastify/accepts': 5.0.4
+      '@fastify/autoload': 6.3.1
+      '@fastify/cors': 10.1.0
+      '@fastify/deepmerge': 2.0.2
+      '@fastify/error': 4.2.0
+      '@fastify/static': 8.3.0
+      '@fastify/swagger': 9.7.0
+      '@fastify/under-pressure': 9.0.3
+      '@platformatic/basic': 3.41.0
+      '@platformatic/foundation': 3.41.0
+      '@platformatic/generators': 3.41.0
+      '@platformatic/metrics': 3.41.0
+      '@platformatic/scalar-theme': 3.41.0
+      '@platformatic/telemetry': 3.41.0
+      '@scalar/fastify-api-reference': 1.34.6(typescript@5.9.3)
+      '@types/node': 22.19.15
+      '@types/ws': 8.18.1
+      ajv: 8.18.0
+      cli-progress: 3.12.0
+      close-with-grace: 2.5.0
+      code-block-writer: 13.0.3
+      colorette: 2.0.20
+      console-table-printer: 2.15.0
+      env-schema: 7.0.0
+      execa: 9.6.1
+      fast-json-patch: 3.1.1
+      fastify: 5.8.1
+      fastify-plugin: 5.1.0
+      graphql: 16.13.1
+      help-me: 5.0.0
+      mercurius: 16.8.0(graphql@16.13.1)
+      minimist: 1.2.8
+      my-ua-parser: 2.0.4
+      ora: 6.3.1
+      pino: 9.14.0
+      pino-pretty: 13.1.3
+      rfdc: 1.4.1
+      semgrator: 0.3.0
+      undici: 7.22.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@platformatic/telemetry@3.41.0':
+    dependencies:
+      '@fastify/swagger': 9.7.0
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-undici': 0.14.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.36.0
+      '@platformatic/foundation': 3.41.0
+      fast-uri: 3.1.0
+      fastify-plugin: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@platformatic/undici-cache-memory@0.8.4': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@react-router/node@7.13.1(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
@@ -4326,7 +6091,58 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@scalar/core@0.3.14':
+    dependencies:
+      '@scalar/types': 0.2.13
+
+  '@scalar/fastify-api-reference@1.34.6(typescript@5.9.3)':
+    dependencies:
+      '@scalar/core': 0.3.14
+      '@scalar/openapi-parser': 0.20.1(typescript@5.9.3)
+      '@scalar/openapi-types': 0.3.7
+      fastify-plugin: 4.5.1
+      github-slugger: 2.0.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/helpers@0.0.8': {}
+
+  '@scalar/json-magic@0.3.1(typescript@5.9.3)':
+    dependencies:
+      '@scalar/helpers': 0.0.8
+      vue: 3.5.30(typescript@5.9.3)
+      yaml: 2.8.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/openapi-parser@0.20.1(typescript@5.9.3)':
+    dependencies:
+      '@scalar/json-magic': 0.3.1(typescript@5.9.3)
+      '@scalar/openapi-types': 0.3.7
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonpointer: 5.0.1
+      leven: 4.1.0
+      yaml: 2.8.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@scalar/openapi-types@0.3.7':
+    dependencies:
+      zod: 3.24.1
+
+  '@scalar/types@0.2.13':
+    dependencies:
+      '@scalar/openapi-types': 0.3.7
+      nanoid: 5.1.5
+      zod: 3.24.1
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@sindresorhus/is@5.6.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@smithy/abort-controller@4.2.11':
     dependencies:
@@ -4719,6 +6535,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/luxon@3.7.1': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/node@22.19.15':
@@ -4734,6 +6552,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4846,13 +6668,69 @@ snapshots:
       '@vercel/oidc': 3.2.0
       mixpart: 0.0.5
 
-  '@workflow/astro@4.0.0-beta.41':
+  '@vue/compiler-core@3.5.30':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/shared': 3.5.30
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.30':
+    dependencies:
+      '@vue/compiler-core': 3.5.30
+      '@vue/shared': 3.5.30
+
+  '@vue/compiler-sfc@3.5.30':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@vue/compiler-core': 3.5.30
+      '@vue/compiler-dom': 3.5.30
+      '@vue/compiler-ssr': 3.5.30
+      '@vue/shared': 3.5.30
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.8
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.30':
+    dependencies:
+      '@vue/compiler-dom': 3.5.30
+      '@vue/shared': 3.5.30
+
+  '@vue/reactivity@3.5.30':
+    dependencies:
+      '@vue/shared': 3.5.30
+
+  '@vue/runtime-core@3.5.30':
+    dependencies:
+      '@vue/reactivity': 3.5.30
+      '@vue/shared': 3.5.30
+
+  '@vue/runtime-dom@3.5.30':
+    dependencies:
+      '@vue/reactivity': 3.5.30
+      '@vue/runtime-core': 3.5.30
+      '@vue/shared': 3.5.30
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.30
+      '@vue/shared': 3.5.30
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@vue/shared@3.5.30': {}
+
+  '@watchable/unpromise@1.0.2': {}
+
+  '@workflow/astro@4.0.0-beta.41(@opentelemetry/api@1.9.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.1-beta.58
-      '@workflow/rollup': 4.0.0-beta.24
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.0-beta.24(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.0-beta.17
+      '@workflow/vite': 4.0.0-beta.17(@opentelemetry/api@1.9.0)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -4861,10 +6739,10 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/builders@4.0.1-beta.58':
+  '@workflow/builders@4.0.1-beta.58(@opentelemetry/api@1.9.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/core': 4.2.0-beta.67
+      '@workflow/core': 4.2.0-beta.67(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0-beta.18
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
       '@workflow/utils': 4.1.0-beta.13
@@ -4881,21 +6759,21 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/cli@4.2.0-beta.67(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@workflow/cli@4.2.0-beta.67(@opentelemetry/api@1.9.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@oclif/core': 4.8.1
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.0.1-beta.58
-      '@workflow/core': 4.2.0-beta.67
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.0-beta.67(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0-beta.18
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
       '@workflow/utils': 4.1.0-beta.13
       '@workflow/web': 4.1.0-beta.39(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@workflow/world': 4.1.0-beta.11(zod@4.3.6)
-      '@workflow/world-local': 4.1.0-beta.40
-      '@workflow/world-vercel': 4.1.0-beta.41
+      '@workflow/world-local': 4.1.0-beta.40(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.0-beta.41(@opentelemetry/api@1.9.0)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -4921,7 +6799,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@workflow/core@4.2.0-beta.67':
+  '@workflow/core@4.2.0-beta.67(@opentelemetry/api@1.9.0)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -4932,8 +6810,8 @@ snapshots:
       '@workflow/serde': 4.1.0-beta.2
       '@workflow/utils': 4.1.0-beta.13
       '@workflow/world': 4.1.0-beta.11(zod@4.3.6)
-      '@workflow/world-local': 4.1.0-beta.40
-      '@workflow/world-vercel': 4.1.0-beta.41
+      '@workflow/world-local': 4.1.0-beta.40(@opentelemetry/api@1.9.0)
+      '@workflow/world-vercel': 4.1.0-beta.41(@opentelemetry/api@1.9.0)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.6.3
       ms: 2.1.3
@@ -4941,6 +6819,8 @@ snapshots:
       seedrandom: 3.0.5
       ulid: 3.0.2
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - aws-crt
       - supports-color
@@ -4950,13 +6830,13 @@ snapshots:
       '@workflow/utils': 4.1.0-beta.13
       ms: 2.1.3
 
-  '@workflow/nest@0.0.0-beta.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)':
+  '@workflow/nest@0.0.0-beta.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)':
     dependencies:
       '@nestjs/common': 11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.0(@swc/core@1.15.3)(chokidar@5.0.0)
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.1-beta.58
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -4965,30 +6845,30 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/next@4.0.1-beta.63(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@workflow/next@4.0.1-beta.63(@opentelemetry/api@1.9.0)(next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.1-beta.58
-      '@workflow/core': 4.2.0-beta.67
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.0-beta.67(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
       - aws-crt
       - supports-color
 
-  '@workflow/nitro@4.0.1-beta.62':
+  '@workflow/nitro@4.0.1-beta.62(@opentelemetry/api@1.9.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.1-beta.58
-      '@workflow/core': 4.2.0-beta.67
-      '@workflow/rollup': 4.0.0-beta.24
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
+      '@workflow/core': 4.2.0-beta.67(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.0-beta.24(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.0-beta.17
+      '@workflow/vite': 4.0.0-beta.17(@opentelemetry/api@1.9.0)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -4997,10 +6877,10 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/nuxt@4.0.1-beta.51':
+  '@workflow/nuxt@4.0.1-beta.51(@opentelemetry/api@1.9.0)':
     dependencies:
       '@nuxt/kit': 4.3.1
-      '@workflow/nitro': 4.0.1-beta.62
+      '@workflow/nitro': 4.0.1-beta.62(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -5008,10 +6888,10 @@ snapshots:
       - magicast
       - supports-color
 
-  '@workflow/rollup@4.0.0-beta.24':
+  '@workflow/rollup@4.0.0-beta.24(@opentelemetry/api@1.9.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.1-beta.58
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -5022,13 +6902,13 @@ snapshots:
 
   '@workflow/serde@4.1.0-beta.2': {}
 
-  '@workflow/sveltekit@4.0.0-beta.56':
+  '@workflow/sveltekit@4.0.0-beta.56(@opentelemetry/api@1.9.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.1-beta.58
-      '@workflow/rollup': 4.0.0-beta.24
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.0-beta.24(@opentelemetry/api@1.9.0)
       '@workflow/swc-plugin': 4.1.0-beta.18(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.0-beta.17
+      '@workflow/vite': 4.0.0-beta.17(@opentelemetry/api@1.9.0)
       exsolve: 1.0.8
       fs-extra: 11.3.4
       pathe: 2.0.3
@@ -5050,9 +6930,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  '@workflow/vite@4.0.0-beta.17':
+  '@workflow/vite@4.0.0-beta.17(@opentelemetry/api@1.9.0)':
     dependencies:
-      '@workflow/builders': 4.0.1-beta.58
+      '@workflow/builders': 4.0.1-beta.58(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -5069,7 +6949,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@workflow/world-local@4.1.0-beta.40':
+  '@workflow/world-local@4.1.0-beta.40(@opentelemetry/api@1.9.0)':
     dependencies:
       '@vercel/queue': 0.1.1
       '@workflow/errors': 4.1.0-beta.18
@@ -5079,8 +6959,10 @@ snapshots:
       ulid: 3.0.2
       undici: 7.22.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
-  '@workflow/world-vercel@4.1.0-beta.41':
+  '@workflow/world-vercel@4.1.0-beta.41(@opentelemetry/api@1.9.0)':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@vercel/queue': 0.1.1
@@ -5089,6 +6971,8 @@ snapshots:
       cbor-x: 1.6.0
       undici: 7.22.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
   '@workflow/world@4.1.0-beta.10(zod@4.3.6)':
     dependencies:
@@ -5201,6 +7085,10 @@ snapshots:
     dependencies:
       arch: 3.0.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   abstract-logging@2.0.1: {}
 
   accepts@1.3.8:
@@ -5208,11 +7096,24 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -5319,6 +7220,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  astral-regex@2.0.0: {}
+
   async-function@1.0.0: {}
 
   async-listen@3.0.0: {}
@@ -5390,6 +7293,14 @@ snapshots:
       execa: 5.1.1
       find-versions: 5.1.0
 
+  bintrees@1.0.2: {}
+
+  bl@5.1.0:
+    dependencies:
+      buffer: 6.0.3
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
@@ -5406,6 +7317,11 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  boring-name-generator@1.0.3:
+    dependencies:
+      commander: 6.2.1
+      lodash: 4.17.23
 
   bowser@2.14.1: {}
 
@@ -5436,6 +7352,11 @@ snapshots:
   buffer-crc32@0.2.13: {}
 
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -5521,6 +7442,15 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  change-case-all@2.1.0:
+    dependencies:
+      change-case: 5.4.4
+      sponge-case: 2.0.3
+      swap-case: 3.0.3
+      title-case: 3.0.3
+
+  change-case@5.4.4: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -5535,28 +7465,51 @@ snapshots:
 
   citty@0.2.1: {}
 
+  cjs-module-lexer@1.4.3: {}
+
+  clean-stack@2.2.0: {}
+
   clean-stack@3.0.1:
     dependencies:
       escape-string-regexp: 4.0.0
 
   cli-boxes@3.0.0: {}
 
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
+
+  cli-progress@3.12.0:
+    dependencies:
+      string-width: 4.2.3
 
   cli-spinners@2.9.2: {}
 
   client-only@0.0.1: {}
 
-  clone@1.0.4:
-    optional: true
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clone@1.0.4: {}
+
+  close-with-grace@2.5.0: {}
+
+  code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@2.0.20: {}
 
   commander@6.2.1: {}
 
@@ -5570,9 +7523,15 @@ snapshots:
 
   consola@3.4.2: {}
 
+  console-table-printer@2.15.0:
+    dependencies:
+      simple-wcswidth: 1.1.2
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
+
+  content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
 
@@ -5581,6 +7540,11 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  cron@4.4.0:
+    dependencies:
+      '@types/luxon': 3.7.1
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5610,6 +7574,10 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  dateformat@4.6.3: {}
+
+  debounce@2.2.0: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -5636,7 +7604,6 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
-    optional: true
 
   defaults@2.0.2: {}
 
@@ -5685,6 +7652,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   easy-table@1.2.0:
     dependencies:
       ansi-regex: 5.0.1
@@ -5703,10 +7677,20 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@7.0.1: {}
+
+  env-schema@7.0.0:
+    dependencies:
+      ajv: 8.18.0
 
   environment@1.1.0: {}
 
@@ -5842,6 +7826,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
@@ -5968,6 +7954,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -5976,11 +7964,15 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - bare-abort-controller
+
+  events@3.3.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -5993,6 +7985,21 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
 
   express@4.22.1:
     dependencies:
@@ -6043,13 +8050,27 @@ snapshots:
       ext-list: 2.2.2
       sort-keys-length: 1.0.1
 
+  fast-copy@4.0.2: {}
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
 
+  fast-json-patch@3.1.1: {}
+
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-json-stringify@5.16.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.1.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-deep-equal: 3.1.3
+      fast-uri: 2.4.0
+      json-schema-ref-resolver: 1.0.1
+      rfdc: 1.4.1
 
   fast-json-stringify@6.3.0:
     dependencies:
@@ -6068,6 +8089,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-uri@2.4.0: {}
+
   fast-uri@3.1.0: {}
 
   fast-xml-builder@1.0.0: {}
@@ -6076,6 +8099,12 @@ snapshots:
     dependencies:
       fast-xml-builder: 1.0.0
       strnum: 2.2.0
+
+  fastest-levenshtein@1.0.16: {}
+
+  fastify-plugin@4.5.1: {}
+
+  fastify-plugin@5.1.0: {}
 
   fastify@5.8.1:
     dependencies:
@@ -6095,6 +8124,11 @@ snapshots:
       semver: 7.7.4
       toad-cache: 3.7.0
 
+  fastparallel@2.4.1:
+    dependencies:
+      reusify: 1.1.0
+      xtend: 4.0.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -6104,6 +8138,10 @@ snapshots:
       picomatch: 4.0.3
 
   fflate@0.8.2: {}
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6193,6 +8231,8 @@ snapshots:
 
   form-data-encoder@2.1.4: {}
 
+  forwarded-parse@2.1.2: {}
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -6216,7 +8256,13 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   generator-function@2.0.1: {}
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
 
@@ -6242,6 +8288,11 @@ snapshots:
 
   get-stream@6.0.1: {}
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -6261,6 +8312,8 @@ snapshots:
       nypm: 0.6.5
       pathe: 2.0.3
 
+  github-slugger@2.0.0: {}
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -6274,6 +8327,12 @@ snapshots:
       minimatch: 10.2.4
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
       path-scurry: 2.0.2
 
   globals@14.0.0: {}
@@ -6307,6 +8366,18 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphql-jit@0.8.7(graphql@16.13.1):
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.1)
+      fast-json-stringify: 5.16.1
+      generate-function: 2.3.1
+      graphql: 16.13.1
+      lodash.memoize: 4.1.2
+      lodash.merge: 4.6.2
+      lodash.mergewith: 4.6.2
+
+  graphql@16.13.1: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -6331,6 +8402,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  help-me@5.0.0: {}
+
   http-cache-semantics@4.2.0: {}
 
   http-errors@2.0.1:
@@ -6348,6 +8421,14 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  human-signals@8.0.1: {}
+
+  hyperid@3.3.0:
+    dependencies:
+      buffer: 5.7.1
+      uuid: 8.3.2
+      uuid-parse: 1.1.0
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -6362,6 +8443,13 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
 
@@ -6464,6 +8552,10 @@ snapshots:
 
   is-plain-obj@1.1.0: {}
 
+  is-plain-obj@4.1.0: {}
+
+  is-property@1.0.2: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6478,6 +8570,8 @@ snapshots:
       call-bound: 1.0.4
 
   is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -6546,6 +8640,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -6554,9 +8650,21 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-ref-resolver@1.0.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+
   json-schema-ref-resolver@3.0.0:
     dependencies:
       dequal: 2.0.3
+
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-uri: 3.1.0
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   json-schema-traverse@0.4.1: {}
 
@@ -6571,6 +8679,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonpointer@5.0.1: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -6588,6 +8698,10 @@ snapshots:
   klona@2.0.6: {}
 
   knitwork@1.3.0: {}
+
+  leven@3.1.0: {}
+
+  leven@4.1.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -6616,12 +8730,29 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
+  lodash.camelcase@4.3.0: {}
+
+  lodash.memoize@4.1.2: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.mergewith@4.6.2: {}
+
+  lodash.truncate@4.4.2: {}
+
+  lodash@4.17.23: {}
+
+  log-symbols@5.1.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -6631,6 +8762,8 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
+  luxon@3.7.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6638,6 +8771,27 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0: {}
+
+  mercurius@16.8.0(graphql@16.13.1):
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@fastify/static': 9.0.0
+      '@fastify/websocket': 11.2.0
+      fastify-plugin: 5.1.0
+      graphql: 16.13.1
+      graphql-jit: 0.8.7(graphql@16.13.1)
+      mqemitter: 7.1.0
+      p-map: 4.0.0
+      quick-lru: 7.3.0
+      readable-stream: 4.7.0
+      safe-stable-stringify: 2.5.0
+      secure-json-parse: 4.1.0
+      single-user-cache: 2.1.0
+      tiny-lru: 11.4.7
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   merge-descriptors@1.0.3: {}
 
@@ -6654,6 +8808,8 @@ snapshots:
       mime-db: 1.52.0
 
   mime@1.6.0: {}
+
+  mime@3.0.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -6679,6 +8835,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
 
   mixpart@0.0.4: {}
@@ -6692,11 +8850,26 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
+  mnemonist@0.40.0:
+    dependencies:
+      obliterator: 2.0.5
+
+  module-details-from-path@1.0.4: {}
+
+  mqemitter@7.1.0:
+    dependencies:
+      fastparallel: 2.4.1
+      qlobber: 8.0.1
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
 
+  my-ua-parser@2.0.4: {}
+
   nanoid@3.3.11: {}
+
+  nanoid@5.1.5: {}
 
   nanoid@5.1.6: {}
 
@@ -6720,7 +8893,7 @@ snapshots:
       - supports-color
       - typescript
 
-  next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 15.5.12
       '@swc/helpers': 0.5.15
@@ -6738,6 +8911,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.12
       '@next/swc-win32-arm64-msvc': 15.5.12
       '@next/swc-win32-x64-msvc': 15.5.12
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6762,6 +8936,11 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   nypm@0.6.5:
     dependencies:
@@ -6805,6 +8984,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obliterator@2.0.5: {}
+
   ohash@2.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
@@ -6812,6 +8993,10 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -6834,6 +9019,8 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openapi-types@12.1.3: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -6842,6 +9029,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@6.3.1:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 4.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 1.3.0
+      log-symbols: 5.1.0
+      stdin-discarder: 0.1.0
+      strip-ansi: 7.2.0
+      wcwidth: 1.0.1
 
   ora@8.2.0:
     dependencies:
@@ -6856,6 +9055,17 @@ snapshots:
       strip-ansi: 7.2.0
 
   os-paths@4.4.0: {}
+
+  otlp-logger@1.1.13(@opentelemetry/api@1.9.0):
+    dependencies:
+      '@opentelemetry/api-logs': 0.206.0
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.206.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.206.0(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
 
   own-keys@1.0.1:
     dependencies:
@@ -6881,11 +9091,17 @@ snapshots:
     dependencies:
       p-limit: 4.0.0
 
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+
   package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-ms@4.0.0: {}
 
   parseurl@1.3.3: {}
 
@@ -6894,6 +9110,8 @@ snapshots:
   path-exists@5.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -6953,9 +9171,37 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
+
+  pino-opentelemetry-transport@2.0.0(@opentelemetry/api@1.9.0)(pino@9.14.0):
+    dependencies:
+      otlp-logger: 1.1.13(@opentelemetry/api@1.9.0)
+      pino: 9.14.0
+      pino-abstract-transport: 3.0.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
 
   pino-std-serializers@7.1.0: {}
 
@@ -6972,6 +9218,20 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
 
   piscina@4.9.2:
     optionalDependencies:
@@ -6997,6 +9257,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postgrator@8.0.0:
     dependencies:
       glob: 11.1.0
@@ -7013,9 +9279,20 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
+
+  process@0.11.10: {}
+
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      tdigest: 0.1.2
 
   prop-types@15.8.1:
     dependencies:
@@ -7023,12 +9300,34 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.15
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
+
+  qlobber@8.0.1: {}
 
   qs@6.14.2:
     dependencies:
@@ -7037,6 +9336,8 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
+
+  quick-lru@7.3.0: {}
 
   range-parser@1.2.1: {}
 
@@ -7074,6 +9375,20 @@ snapshots:
 
   react@19.2.4: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
@@ -7102,13 +9417,29 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+      resolve: 1.22.11
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.11:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   resolve@2.0.0-next.6:
     dependencies:
@@ -7122,6 +9453,11 @@ snapshots:
   responselike@3.0.0:
     dependencies:
       lowercase-keys: 3.0.0
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
     dependencies:
@@ -7180,6 +9516,12 @@ snapshots:
   seek-bzip@2.0.0:
     dependencies:
       commander: 6.2.1
+
+  semgrator@0.3.0:
+    dependencies:
+      abstract-logging: 2.0.1
+      rfdc: 1.4.1
+      semver: 7.7.4
 
   semver-regex@4.0.5: {}
 
@@ -7314,7 +9656,19 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-wcswidth@1.1.2: {}
+
+  single-user-cache@2.1.0:
+    dependencies:
+      safe-stable-stringify: 2.5.0
+
   slash@3.0.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   sonic-boom@4.2.1:
     dependencies:
@@ -7334,7 +9688,13 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sponge-case@2.0.3: {}
+
   statuses@2.0.2: {}
+
+  stdin-discarder@0.1.0:
+    dependencies:
+      bl: 5.1.0
 
   stdin-discarder@0.2.2: {}
 
@@ -7342,6 +9702,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-shift@1.0.3: {}
 
   streamx@2.23.0:
     dependencies:
@@ -7408,6 +9770,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -7423,7 +9789,11 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-final-newline@4.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   strnum@2.2.0: {}
 
@@ -7453,6 +9823,18 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swap-case@3.0.3: {}
+
+  systeminformation@5.31.4: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.18.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   tapable@2.3.0: {}
 
   tar-stream@3.1.8:
@@ -7465,6 +9847,10 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   teex@1.0.1:
     dependencies:
@@ -7484,11 +9870,17 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
 
   through@2.3.8: {}
+
+  tiny-lru@11.4.7: {}
 
   tinyexec@1.0.2: {}
 
@@ -7496,6 +9888,10 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  title-case@3.0.3:
+    dependencies:
+      tslib: 2.8.1
 
   toad-cache@3.7.0: {}
 
@@ -7606,7 +10002,18 @@ snapshots:
       magic-string: 0.30.21
       unplugin: 2.3.11
 
+  undici-thread-interceptor@1.3.1:
+    dependencies:
+      fastq: 1.20.1
+      hyperid: 3.3.0
+      light-my-request: 6.6.0
+      undici: 7.22.0
+
   undici-types@6.21.0: {}
+
+  undici@6.23.0: {}
+
+  undici@7.18.2: {}
 
   undici@7.22.0: {}
 
@@ -7637,19 +10044,49 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  util-deprecate@1.0.2: {}
+
   utils-merge@1.0.1: {}
 
+  uuid-parse@1.1.0: {}
+
+  uuid@8.3.2: {}
+
   vary@1.1.2: {}
+
+  vue@3.5.30(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.30
+      '@vue/compiler-sfc': 3.5.30
+      '@vue/runtime-dom': 3.5.30
+      '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@5.9.3))
+      '@vue/shared': 3.5.30
+    optionalDependencies:
+      typescript: 5.9.3
 
   watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
+  wattpm@3.41.0:
+    dependencies:
+      '@fastify/websocket': 11.2.0
+      '@platformatic/control': 3.41.0
+      '@platformatic/foundation': 3.41.0
+      '@platformatic/runtime': 3.41.0
+      colorette: 2.0.20
+      pino-pretty: 13.1.3
+      split2: 4.2.0
+      table: 6.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-    optional: true
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -7710,20 +10147,22 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.2.0-beta.67(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+  workflow@4.2.0-beta.67(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
-      '@workflow/astro': 4.0.0-beta.41
-      '@workflow/cli': 4.2.0-beta.67(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
-      '@workflow/core': 4.2.0-beta.67
+      '@workflow/astro': 4.0.0-beta.41(@opentelemetry/api@1.9.0)
+      '@workflow/cli': 4.2.0-beta.67(@opentelemetry/api@1.9.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@workflow/core': 4.2.0-beta.67(@opentelemetry/api@1.9.0)
       '@workflow/errors': 4.1.0-beta.18
-      '@workflow/nest': 0.0.0-beta.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
-      '@workflow/next': 4.0.1-beta.63(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@workflow/nitro': 4.0.1-beta.62
-      '@workflow/nuxt': 4.0.1-beta.51
-      '@workflow/rollup': 4.0.0-beta.24
-      '@workflow/sveltekit': 4.0.0-beta.56
+      '@workflow/nest': 0.0.0-beta.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16(@nestjs/common@11.1.16(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
+      '@workflow/next': 4.0.1-beta.63(@opentelemetry/api@1.9.0)(next@15.5.12(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@workflow/nitro': 4.0.1-beta.62(@opentelemetry/api@1.9.0)
+      '@workflow/nuxt': 4.0.1-beta.51(@opentelemetry/api@1.9.0)
+      '@workflow/rollup': 4.0.0-beta.24(@opentelemetry/api@1.9.0)
+      '@workflow/sveltekit': 4.0.0-beta.56(@opentelemetry/api@1.9.0)
       '@workflow/typescript-plugin': 4.0.1-beta.5(typescript@5.9.3)
       ms: 2.1.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
       - '@nestjs/common'
       - '@nestjs/core'
@@ -7749,6 +10188,10 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
+  ws@8.19.0: {}
+
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
@@ -7763,6 +10206,24 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
+  yaml@2.8.0: {}
+
+  yaml@2.8.2: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yauzl@3.2.0:
     dependencies:
       buffer-crc32: 0.2.13
@@ -7771,6 +10232,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yoctocolors@2.1.2: {}
+
+  zod@3.24.1: {}
 
   zod@4.1.11: {}
 


### PR DESCRIPTION
## Summary
- Restores all files from the `workflow-to-watt` branch that were lost during the merge of PR #7: `Dockerfile`, `watt.json`, `plugins/`, `lib/`, `queue/`, `migrations/`
- Adds separate `publish.yml` workflow that builds and pushes the Docker image to GHCR
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env to both CI and publish workflows to fix Node.js 20 deprecation warning

