### PR TITLE
fix: add safety-net poll interval to poller

### DIFF
--- a/e2e/test/vercel-e2e.test.ts
+++ b/e2e/test/vercel-e2e.test.ts
@@ -119,7 +119,7 @@ test('errorRetryFatal: FatalError fails immediately without retries', { timeout:
 test('errorRetryCustomDelay: RetryableError respects retryAfter', { timeout: 120_000 }, async () => {
   const startTime = Date.now()
   const runId = await triggerE2eWorkflow('errorRetryCustomDelay')
-  const run = await waitForRunStatus(runId, 'completed', 110_000)
+  const run = await waitForRunStatus(runId, 'completed', 90_000)
   const elapsed = Date.now() - startTime
   assert.equal(run.status, 'completed')
   assert.ok(elapsed >= 9_000, `retry delay should be at least 9s, got ${elapsed}ms`)
@@ -157,7 +157,7 @@ test('errorStepCrossFile: step error from imported helper is caught', { timeout:
 
 test('errorRetrySuccess: regular Error retries until success (with metadata)', { timeout: 120_000 }, async () => {
   const runId = await triggerE2eWorkflow('errorRetrySuccess')
-  const run = await waitForRunStatus(runId, 'completed', 110_000)
+  const run = await waitForRunStatus(runId, 'completed', 90_000)
   assert.equal(run.status, 'completed')
 })
 

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@fastify/autoload": "^6.0.3",
     "@fastify/error": "^4.1.0",
-    "@platformatic/leader": "^0.1.0",
+    "@platformatic/leader": "^0.2.0",
     "@platformatic/service": "^3.40.0",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.1.0",

--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -5,6 +5,16 @@ import { dispatchMessage, type DispatchResult } from './dispatcher.ts'
 import { getRetryDelay, isMaxAttempts } from './retry.ts'
 
 const ORPHAN_CHECK_INTERVAL = 60_000
+// Safety-net poll interval: scheduleNextWakeup() is fire-and-forget to avoid
+// blocking pendingNotify re-runs. When multiple executeOnce() cycles run
+// back-to-back, two concurrent scheduleNextWakeup() calls can race — the
+// second clears the first's deferredTimer, then queries the DB after the
+// deferred message's deliver_at has passed NOW(), finding nothing to schedule.
+// The deferred message is stuck: deliver_at in the past but status still
+// 'deferred', with no timer or notification to trigger promotion.
+// This interval ensures executeOnce() runs periodically regardless, so any
+// stuck deferred messages are promoted within a bounded time window.
+const SAFETY_POLL_INTERVAL = 5_000
 const LEADER_LOCK_ID = 42424242
 const DEFERRED_CHANNEL = 'deferred_messages'
 
@@ -12,6 +22,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
   let stopped = false
   let deferredTimer: ReturnType<typeof setTimeout> | null = null
   let orphanTimer: ReturnType<typeof setInterval> | null = null
+  let safetyTimer: ReturnType<typeof setInterval> | null = null
   let listenClient: pg.Client | null = null
   let executing = false
   let pendingNotify = false
@@ -22,7 +33,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
     pool,
     lock: LEADER_LOCK_ID,
     log,
-    channels: [{ channel: '__leader_noop__', onNotification: () => {} }],
+    channels: [],
     onLeadershipChange: (isLeader: boolean) => {
       if (isLeader) {
         startPolling()
@@ -36,6 +47,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
     stopped = false
     setupListener()
     orphanTimer = setInterval(checkOrphans, ORPHAN_CHECK_INTERVAL)
+    safetyTimer = setInterval(() => execute(), SAFETY_POLL_INTERVAL)
     execute()
   }
 
@@ -43,6 +55,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
     stopped = true
     if (deferredTimer) { clearTimeout(deferredTimer); deferredTimer = null }
     if (orphanTimer) { clearInterval(orphanTimer); orphanTimer = null }
+    if (safetyTimer) { clearInterval(safetyTimer); safetyTimer = null }
     teardownListener()
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^4.1.0
         version: 4.2.0
       '@platformatic/leader':
-        specifier: ^0.1.0
-        version: 0.1.1
+        specifier: ^0.2.0
+        version: 0.2.0
       '@platformatic/service':
         specifier: ^3.40.0
         version: 3.41.0(typescript@5.9.3)
@@ -1225,8 +1225,8 @@ packages:
     resolution: {integrity: sha512-wrGVupCHmvLXRl/7A0I+T0Nrc2avUqvYXeg3mK3UpbA9QoR9bki9NOHtznqs7nC97HPDXiDp1+bfldT4GvVu/g==}
     engines: {node: '>=22.19.0'}
 
-  '@platformatic/leader@0.1.1':
-    resolution: {integrity: sha512-BHp8sHN8x/HGjj9G6Dt6Dc6f/zW02oQ9CMxXGsOyTMbs5HjQ9xJ3eGwKJG5KJOBja7/oGglLWh8MY692egWO/A==}
+  '@platformatic/leader@0.2.0':
+    resolution: {integrity: sha512-Sc2kdrlrJvSnWZyt2XiCDaPHFILBlOftKrer2zDTrzgh6pv4v18hOG5MUJy8bF/dQtnIo91HGUpf3WNGBdRuPQ==}
     engines: {node: '>=22.0.0'}
 
   '@platformatic/metrics@3.41.0':
@@ -5926,7 +5926,7 @@ snapshots:
       '@fastify/error': 4.2.0
       '@watchable/unpromise': 1.0.2
 
-  '@platformatic/leader@0.1.1':
+  '@platformatic/leader@0.2.0':
     dependencies:
       pg: 8.20.0
       pino: 10.3.1


### PR DESCRIPTION
## Summary
- Add a 5-second safety-net poll interval to the queue poller to prevent deferred messages from getting stuck
- The fire-and-forget `scheduleNextWakeup()` can race with itself when multiple `executeOnce()` cycles run back-to-back — one clears the other's `deferredTimer`, and if the `deliver_at` has passed by the time the DB is queried, no timer is set and the message is stuck forever
- Also reverts overly aggressive e2e timeout bumps (110s back to 90s) since the root cause is now fixed

## Test plan
- [ ] CI e2e tests pass — specifically `errorRetrySuccess` which was consistently stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)