### PR TITLE
world: skip handler registration in K8s to fix cross-namespace dispatch

### DIFF
--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -21,8 +21,14 @@ export function createPlatformaticWorld (config: PlatformaticWorldConfig): World
     ...createStreamer(client),
     getEncryptionKeyForRun: createEncryption(client),
     async start () {
-      // Register this process as a queue handler with the workflow service.
-      // The test server (world-testing) sets process.env.PORT after listening.
+      // In K8s, ICC registers queue handlers with proper FQDN URLs
+      // (http://<service>.<namespace>.svc.cluster.local:<port>/...) so the
+      // workflow service can dispatch cross-namespace.  Registering here with
+      // localhost would create a duplicate handler that fails when picked.
+      if (isRunningInK8s()) return
+
+      // Local dev (no ICC) — register with localhost so the workflow service
+      // running on the same machine can reach us.
       const port = process.env.PORT
       if (!port) return
       const baseUrl = `http://localhost:${port}`
@@ -48,13 +54,14 @@ export interface CreateWorldOptions {
   deploymentVersion: string
 }
 
-const SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
-const SA_NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
-const SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+function saPath (file: string): string {
+  const base = process.env.PLT_WORLD_SA_PATH || '/var/run/secrets/kubernetes.io/serviceaccount'
+  return `${base}/${file}`
+}
 
 function isRunningInK8s (): boolean {
   try {
-    readFileSync(SA_TOKEN_PATH)
+    readFileSync(saPath('token'))
     return true
   } catch {
     return false
@@ -63,12 +70,12 @@ function isRunningInK8s (): boolean {
 
 async function readVersionFromK8sApi (): Promise<string | undefined> {
   try {
-    const token = readFileSync(SA_TOKEN_PATH, 'utf8').trim()
-    const namespace = readFileSync(SA_NAMESPACE_PATH, 'utf8').trim()
+    const token = readFileSync(saPath('token'), 'utf8').trim()
+    const namespace = readFileSync(saPath('namespace'), 'utf8').trim()
     const podName = process.env.HOSTNAME
     if (!podName) return undefined
 
-    const ca = readFileSync(SA_CA_PATH)
+    const ca = readFileSync(saPath('ca.crt'))
     const dispatcher = new Agent({ connect: { ca } })
     const res = await fetch(
       `https://kubernetes.default.svc/api/v1/namespaces/${namespace}/pods/${podName}`,

--- a/packages/world/test/world.test.ts
+++ b/packages/world/test/world.test.ts
@@ -1,6 +1,10 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { createWorld } from '../src/index.ts'
+import { createServer } from 'node:http'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createWorld, createPlatformaticWorld } from '../src/index.ts'
 
 test('throws when PLT_WORLD_SERVICE_URL is not set', () => {
   const original = process.env.PLT_WORLD_SERVICE_URL
@@ -127,5 +131,98 @@ test('env var takes precedence over K8s API lookup', async () => {
     else delete process.env.PLT_WORLD_SERVICE_URL
     if (originalVersion) process.env.PLT_WORLD_DEPLOYMENT_VERSION = originalVersion
     else delete process.env.PLT_WORLD_DEPLOYMENT_VERSION
+  }
+})
+
+test('start() registers handlers in local dev (not K8s)', async () => {
+  let handlerRequest: any = null
+
+  const server = createServer((req, res) => {
+    if (req.url?.includes('/handlers') && req.method === 'POST') {
+      let body = ''
+      req.on('data', (chunk: Buffer) => { body += chunk })
+      req.on('end', () => {
+        handlerRequest = JSON.parse(body)
+        res.writeHead(201, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ registered: true }))
+      })
+    } else {
+      res.writeHead(404)
+      res.end()
+    }
+  })
+
+  await new Promise<void>((resolve) => { server.listen(0, resolve) })
+  const port = (server.address() as any).port
+
+  const originalPort = process.env.PORT
+  process.env.PORT = String(port)
+
+  try {
+    const world = createPlatformaticWorld({
+      serviceUrl: `http://localhost:${port}`,
+      appId: 'test-app',
+      deploymentVersion: 'v1',
+    })
+
+    await world.start!()
+
+    assert.ok(handlerRequest, 'handler registration request should have been made')
+    assert.equal(handlerRequest.deploymentVersion, 'v1')
+    assert.ok(handlerRequest.endpoints.workflow.includes('/.well-known/workflow/v1/flow'))
+    assert.ok(handlerRequest.endpoints.step.includes('/.well-known/workflow/v1/step'))
+    assert.ok(handlerRequest.endpoints.webhook.includes('/.well-known/workflow/v1/webhook'))
+
+    await world.close()
+  } finally {
+    if (originalPort) process.env.PORT = originalPort
+    else delete process.env.PORT
+    server.close()
+  }
+})
+
+test('start() skips handler registration in K8s (ICC handles it)', async () => {
+  let handlerCalled = false
+
+  const server = createServer((req, res) => {
+    if (req.url?.includes('/handlers')) {
+      handlerCalled = true
+    }
+    res.writeHead(201, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ registered: true }))
+  })
+
+  await new Promise<void>((resolve) => { server.listen(0, resolve) })
+  const port = (server.address() as any).port
+
+  // Create a fake K8s service account directory
+  const fakeSaDir = join(tmpdir(), `plt-world-test-sa-${process.pid}`)
+  mkdirSync(fakeSaDir, { recursive: true })
+  writeFileSync(join(fakeSaDir, 'token'), 'fake-sa-token')
+
+  const originalPort = process.env.PORT
+  const originalSaPath = process.env.PLT_WORLD_SA_PATH
+  process.env.PORT = String(port)
+  process.env.PLT_WORLD_SA_PATH = fakeSaDir
+
+  try {
+    const world = createPlatformaticWorld({
+      serviceUrl: `http://localhost:${port}`,
+      appId: 'test-app',
+      deploymentVersion: 'v1',
+    })
+
+    await world.start!()
+
+    assert.equal(handlerCalled, false, 'handler registration should NOT be called in K8s')
+
+    await world.close()
+  } finally {
+    if (originalPort) process.env.PORT = originalPort
+    else delete process.env.PORT
+    if (originalSaPath) process.env.PLT_WORLD_SA_PATH = originalSaPath
+    else delete process.env.PLT_WORLD_SA_PATH
+    rmSync(fakeSaDir, { recursive: true, force: true })
+    server.close()
   }
 })


### PR DESCRIPTION
## Summary

- In K8s, ICC registers queue handlers with FQDN URLs (`http://<service>.<namespace>.svc.cluster.local:<port>/...`) that work cross-namespace. The world client was also registering with `localhost` URLs under a different `podId`, creating a duplicate handler entry. 
- Skip handler registration in `start()` when running in K8s (detected via service account token presence). Keep localhost registration for local dev where there is no ICC.
- Add `PLT_WORLD_SA_PATH` env var to override the service account path (for testing only).

