### PR TITLE
fix: decode devl-prefixed event data in workflow service

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -17,6 +17,7 @@
     "@fastify/error": "^4.1.0",
     "@platformatic/leader": "^0.1.0",
     "@platformatic/service": "^3.40.0",
+    "devalue": "^5.6.4",
     "fastify": "^5.3.3",
     "fastify-plugin": "^5.1.0",
     "pg": "^8.16.0",

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -1,6 +1,7 @@
 import fp from 'fastify-plugin'
 import { randomUUID } from 'node:crypto'
 import type { FastifyInstance } from 'fastify'
+import { parse as devalueParse } from 'devalue'
 import { RunNotFound, BadRequest } from '../lib/errors.ts'
 import { checkRunQuota, checkEventQuota } from '../lib/quotas.ts'
 import type pg from 'pg'
@@ -20,15 +21,58 @@ function encodeData (data: unknown): Buffer | null {
   return Buffer.from(JSON.stringify(data))
 }
 
-function decodeData (buf: Buffer | null): unknown {
-  if (buf === null) return undefined
-  // Try to detect if it's JSON
-  if (buf[0] === 0x7b || buf[0] === 0x5b || buf[0] === 0x22) {
+// Fields within event data that may contain base64-encoded binary (from SDK serialization)
+const BINARY_EVENT_FIELDS = new Set(['result', 'output', 'input', 'payload', 'metadata'])
+
+// The Vercel workflow SDK serializes data as: 4-byte "devl" header + devalue-encoded payload.
+// devalue is a structured clone serializer that handles circular refs, Dates, Maps, etc.
+function tryDeserialize (buf: Buffer): unknown | undefined {
+  // Check for "devl" (devalue v1) prefix
+  if (buf.length > 4 && buf[0] === 0x64 && buf[1] === 0x65 && buf[2] === 0x76 && buf[3] === 0x6c) {
+    try {
+      return devalueParse(buf.subarray(4).toString('utf-8'))
+    } catch {
+      // not valid devalue payload
+    }
+  }
+  // Plain JSON
+  const first = buf[0]
+  if (first === 0x7b || first === 0x5b || first === 0x22) {
     try {
       return JSON.parse(buf.toString('utf-8'))
     } catch {
-      // Not JSON, return as base64
+      // not valid JSON
     }
+  }
+  return undefined
+}
+
+function tryDecodeBase64 (str: string): unknown {
+  if (str.length < 4 || /\s/.test(str)) return str
+  try {
+    const buf = Buffer.from(str, 'base64')
+    if (buf.toString('base64') !== str) return str
+    const parsed = tryDeserialize(buf)
+    if (parsed !== undefined) return parsed
+  } catch {
+    // Not valid base64 or not devalue/JSON
+  }
+  return str
+}
+
+function decodeData (buf: Buffer | null): unknown {
+  if (buf === null) return undefined
+  const parsed = tryDeserialize(buf)
+  if (parsed !== undefined) {
+    // Decode known binary fields within event data objects
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      for (const key of BINARY_EVENT_FIELDS) {
+        if (typeof (parsed as any)[key] === 'string') {
+          (parsed as any)[key] = tryDecodeBase64((parsed as any)[key])
+        }
+      }
+    }
+    return parsed
   }
   return buf.toString('base64')
 }

--- a/packages/workflow/test/events.test.ts
+++ b/packages/workflow/test/events.test.ts
@@ -1,7 +1,64 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
+import { stringify as devalueStringify } from 'devalue'
 import { setupTest, teardownTest } from './helper.ts'
+import { decodeData, encodeData } from '../plugins/events.ts'
 import type { TestContext } from './helper.ts'
+
+describe('decodeData', () => {
+  it('should decode plain JSON buffers', () => {
+    const buf = Buffer.from(JSON.stringify({ hello: 'world' }))
+    assert.deepEqual(decodeData(buf), { hello: 'world' })
+  })
+
+  it('should return undefined for null', () => {
+    assert.equal(decodeData(null), undefined)
+  })
+
+  it('should return base64 for non-JSON binary', () => {
+    const buf = Buffer.from([0x00, 0x01, 0x02, 0x03])
+    assert.equal(typeof decodeData(buf), 'string')
+  })
+
+  it('should decode devl-prefixed devalue buffers', () => {
+    const obj = { version: 'v2', podId: 'pod-abc' }
+    const payload = devalueStringify(obj)
+    const buf = Buffer.concat([Buffer.from('devl'), Buffer.from(payload)])
+    assert.deepEqual(decodeData(buf), obj)
+  })
+
+  it('should decode base64 fields inside event data objects', () => {
+    // Simulate SDK: result is base64-encoded devl+devalue
+    const stepResult = { greeting: 'Hello World' }
+    const devlBuf = Buffer.concat([Buffer.from('devl'), Buffer.from(devalueStringify(stepResult))])
+    const resultBase64 = devlBuf.toString('base64')
+
+    const eventData = JSON.stringify({ result: resultBase64, stepName: 'myStep' })
+    const decoded = decodeData(Buffer.from(eventData)) as any
+    assert.deepEqual(decoded.result, stepResult)
+    assert.equal(decoded.stepName, 'myStep')
+  })
+
+  it('should decode base64 fields with plain JSON inside', () => {
+    const inner = { foo: 'bar' }
+    const innerBase64 = Buffer.from(JSON.stringify(inner)).toString('base64')
+    const outer = JSON.stringify({ output: innerBase64 })
+    const decoded = decodeData(Buffer.from(outer)) as any
+    assert.deepEqual(decoded.output, inner)
+  })
+
+  it('should not mangle non-base64 string fields', () => {
+    const data = JSON.stringify({ result: 'just a string', name: 'test' })
+    const decoded = decodeData(Buffer.from(data)) as any
+    assert.equal(decoded.name, 'test')
+  })
+
+  it('should round-trip through encodeData and decodeData', () => {
+    const obj = { count: 42, items: ['a', 'b'] }
+    const encoded = encodeData(obj)
+    assert.deepEqual(decodeData(encoded), obj)
+  })
+})
 
 describe('events', () => {
   let ctx: TestContext

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@platformatic/service':
         specifier: ^3.40.0
         version: 3.41.0(typescript@5.9.3)
+      devalue:
+        specifier: ^5.6.4
+        version: 5.6.4
       fastify:
         specifier: ^5.3.3
         version: 5.8.1
@@ -2465,6 +2468,9 @@ packages:
 
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+
+  devalue@5.6.4:
+    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -7639,6 +7645,8 @@ snapshots:
     optional: true
 
   devalue@5.6.3: {}
+
+  devalue@5.6.4: {}
 
   doctrine@2.1.0:
     dependencies:


### PR DESCRIPTION

<img width="536" height="446" alt="image" src="https://github.com/user-attachments/assets/42ec5921-2cd4-43b1-8c9d-ebbc28d249a0" />


## Summary
- ICC dashboard was showing raw base64 strings for event data (step results, run output) instead of decoded JSON
- Root cause: the Vercel workflow SDK serializes data with a 4-byte `devl` (devalue v1) header before the payload. `decodeData()` only checked for JSON-starting bytes (`{`, `[`, `"`) and missed the `devl` prefix, falling through to a raw base64 string return
- Added `devalue` dependency to properly deserialize SDK payloads (structured clone format supporting circular refs, Dates, Maps, etc.)
- Also decodes base64-encoded binary fields (`result`, `output`, `input`, `payload`, `metadata`) nested inside event data objects

## Test plan
- [x] 8 new unit tests for `decodeData`: plain JSON, null, binary, devl+devalue, nested base64 fields, round-trip
- [x] All 32 existing tests pass
- [x] Linting clean
- [x] Verified on live k3d cluster — ICC dashboard now shows decoded JSON for versionCheck workflow events

🤖 Generated with [Claude Code](https://claude.com/claude-code)