### PR TITLE
workflow: add template API, event idempotency, ULID run IDs for replay

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -21,6 +21,7 @@
     "fastify-plugin": "^5.1.0",
     "pg": "^8.16.0",
     "postgrator": "^8.0.0",
+    "ulid": "^3.0.2",
     "undici": "^7.22.0",
     "wattpm": "^3.40.0"
   },

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -134,9 +134,11 @@ async function insertEvent (client: pg.PoolClient, runId: string, appId: number,
   const correlationId = body.correlationId || null
   const eventData = body.eventData ? encodeData(body.eventData) : null
 
-  // Skip duplicate events — the SDK may re-send the same event on retry.
-  // Duplicates in the event log cause "Unconsumed event" errors during replay.
-  if (correlationId) {
+  // Skip duplicate *_created events — the SDK may re-send them on retry or
+  // re-invocation. Duplicates in the event log cause "Unconsumed event" errors
+  // during replay. Only guard _created events because other event types
+  // (e.g. step_started) can legitimately repeat for step retries.
+  if (correlationId && body.eventType.endsWith('_created')) {
     const existing = await client.query(
       `SELECT id FROM workflow_events
        WHERE run_id = $1 AND application_id = $2 AND event_type = $3 AND correlation_id = $4

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -514,7 +514,20 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
           )
 
           if (insertResult.rows.length === 0) {
-            // Token conflict — another active hook already exists
+            // Check if the existing hook belongs to this same run (retry/re-invocation)
+            const existingHook = await client.query(
+              'SELECT id FROM workflow_hooks WHERE token = $1 AND run_id = $2 AND correlation_id = $3 AND status = \'pending\'',
+              [eventData.token, rawRunId, body.correlationId]
+            )
+            if (existingHook.rows.length > 0) {
+              // Same run, same correlation — this is a retry, return the existing hook
+              const eventRow = await insertEvent(client, rawRunId, appId, body)
+              const hookRow = (await client.query('SELECT * FROM workflow_hooks WHERE id = $1', [existingHook.rows[0].id])).rows[0]
+              result = { event: formatEvent(eventRow, resolveData), hook: formatHook(hookRow) }
+              break
+            }
+
+            // Token conflict — another run's active hook already exists
             const conflictBody = {
               eventType: 'hook_conflict',
               correlationId: body.correlationId,

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -131,12 +131,28 @@ function formatWait (row: any) {
 }
 
 async function insertEvent (client: pg.PoolClient, runId: string, appId: number, body: any): Promise<any> {
+  const correlationId = body.correlationId || null
   const eventData = body.eventData ? encodeData(body.eventData) : null
+
+  // Skip duplicate events — the SDK may re-send the same event on retry.
+  // Duplicates in the event log cause "Unconsumed event" errors during replay.
+  if (correlationId) {
+    const existing = await client.query(
+      `SELECT id FROM workflow_events
+       WHERE run_id = $1 AND application_id = $2 AND event_type = $3 AND correlation_id = $4
+       LIMIT 1`,
+      [runId, appId, body.eventType, correlationId]
+    )
+    if (existing.rows.length > 0) {
+      return (await client.query('SELECT * FROM workflow_events WHERE id = $1', [existing.rows[0].id])).rows[0]
+    }
+  }
+
   const result = await client.query(
     `INSERT INTO workflow_events (run_id, application_id, event_type, correlation_id, event_data, spec_version)
      VALUES ($1, $2, $3, $4, $5, $6)
      RETURNING *`,
-    [runId, appId, body.eventType, body.correlationId || null, eventData, body.specVersion || null]
+    [runId, appId, body.eventType, correlationId, eventData, body.specVersion || null]
   )
   return result.rows[0]
 }
@@ -550,15 +566,26 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
         }
 
         case 'wait_created': {
-          const waitId = randomUUID()
           const eventData = body.eventData || {}
           const resumeAt = eventData.resumeAt ? new Date(eventData.resumeAt) : null
 
-          await client.query(
-            `INSERT INTO workflow_waits (id, run_id, application_id, correlation_id, status, resume_at, spec_version)
-             VALUES ($1, $2, $3, $4, 'waiting', $5, $6)`,
-            [waitId, rawRunId, appId, body.correlationId, resumeAt, body.specVersion || null]
+          // Skip duplicate wait creation
+          const existingWait = await client.query(
+            'SELECT id FROM workflow_waits WHERE run_id = $1 AND correlation_id = $2 AND application_id = $3 LIMIT 1',
+            [rawRunId, body.correlationId, appId]
           )
+
+          let waitId
+          if (existingWait.rows.length > 0) {
+            waitId = existingWait.rows[0].id
+          } else {
+            waitId = randomUUID()
+            await client.query(
+              `INSERT INTO workflow_waits (id, run_id, application_id, correlation_id, status, resume_at, spec_version)
+               VALUES ($1, $2, $3, $4, 'waiting', $5, $6)`,
+              [waitId, rawRunId, appId, body.correlationId, resumeAt, body.specVersion || null]
+            )
+          }
 
           const eventRow = await insertEvent(client, rawRunId, appId, body)
           const waitRow = (await client.query('SELECT * FROM workflow_waits WHERE id = $1', [waitId])).rows[0]

--- a/packages/workflow/plugins/hooks.ts
+++ b/packages/workflow/plugins/hooks.ts
@@ -44,13 +44,17 @@ async function hooksPlugin (app: FastifyInstance): Promise<void> {
 
     const offset = query.cursor ? parseInt(query.cursor, 10) : 0
 
-    const conditions = ['application_id = $1', "status != 'disposed'"]
+    const conditions = ['application_id = $1']
     const params: any[] = [appId]
     let paramIdx = 2
 
     if (query.runId) {
+      // When filtering by run, show all hooks including disposed
       conditions.push(`run_id = $${paramIdx++}`)
       params.push(query.runId)
+    } else {
+      // Global list: exclude disposed hooks
+      conditions.push("status != 'disposed'")
     }
 
     params.push(limit + 1)

--- a/packages/workflow/plugins/run-actions.ts
+++ b/packages/workflow/plugins/run-actions.ts
@@ -1,6 +1,8 @@
 import fp from 'fastify-plugin'
-import { randomUUID } from 'node:crypto'
+import { monotonicFactory } from 'ulid'
 import type { FastifyInstance } from 'fastify'
+
+const ulid = monotonicFactory()
 import { RunNotFound, BadRequest } from '../lib/errors.ts'
 import { formatRun, encodeData } from './events.ts'
 
@@ -18,7 +20,7 @@ async function runActionsPlugin (app: FastifyInstance): Promise<void> {
     if (original.rows.length === 0) throw new RunNotFound(runId)
 
     const row = original.rows[0]
-    const newRunId = randomUUID()
+    const newRunId = `wrun_${ulid()}`
 
     const client = await app.pg.connect()
     try {

--- a/packages/workflow/plugins/runs.ts
+++ b/packages/workflow/plugins/runs.ts
@@ -70,6 +70,89 @@ async function runsPlugin (app: FastifyInstance): Promise<void> {
 
     return { data, cursor: nextCursor, hasMore }
   })
+  // Get workflow step template from the most recent completed run
+  // Used by the UI to pre-render step placeholders for in-progress runs
+  app.get('/api/v1/apps/:appId/workflows/:workflowName/template', async (request, reply) => {
+    const { workflowName } = request.params as { workflowName: string }
+    const query = request.query as { deploymentId?: string }
+    const appId = request.appId
+
+    const conditions = ['r.application_id = $1', 'r.workflow_name = $2', "r.status = 'completed'"]
+    const params: any[] = [appId, workflowName]
+    let paramIdx = 3
+
+    if (query.deploymentId) {
+      conditions.push(`r.deployment_id = $${paramIdx++}`)
+      params.push(query.deploymentId)
+    }
+
+    // Find the most recent completed run
+    const runResult = await app.pg.query(
+      `SELECT r.id FROM workflow_runs r
+       WHERE ${conditions.join(' AND ')}
+       ORDER BY r.created_at DESC LIMIT 1`,
+      params
+    )
+
+    if (runResult.rows.length === 0) {
+      reply.code(404)
+      return { error: 'No completed run found for this workflow' }
+    }
+
+    const sourceRunId = runResult.rows[0].id
+
+    // Get all steps from that run, ordered by creation time
+    const stepsResult = await app.pg.query(
+      `SELECT step_name, created_at, started_at, completed_at
+       FROM workflow_steps
+       WHERE run_id = $1 AND application_id = $2
+       ORDER BY created_at ASC`,
+      [sourceRunId, appId]
+    )
+
+    // Check for hooks and waits
+    const hooksResult = await app.pg.query(
+      'SELECT COUNT(*) as count FROM workflow_hooks WHERE run_id = $1 AND application_id = $2',
+      [sourceRunId, appId]
+    )
+    const waitsResult = await app.pg.query(
+      'SELECT COUNT(*) as count FROM workflow_waits WHERE run_id = $1 AND application_id = $2',
+      [sourceRunId, appId]
+    )
+
+    // Build step template with parallel group detection
+    const steps: { stepName: string; order: number; parallelGroup?: number }[] = []
+    let currentOrder = 0
+    let currentGroupId = 0
+    let prevEnd = 0
+
+    for (let i = 0; i < stepsResult.rows.length; i++) {
+      const row = stepsResult.rows[i]
+      const start = new Date(row.started_at || row.created_at).getTime()
+      const end = new Date(row.completed_at || row.started_at || row.created_at).getTime()
+
+      if (i > 0 && start < prevEnd) {
+        // Overlaps with previous — same parallel group
+        steps[steps.length - 1].parallelGroup = currentGroupId
+        steps.push({ stepName: row.step_name, order: currentOrder, parallelGroup: currentGroupId })
+      } else {
+        if (i > 0) {
+          currentOrder++
+          currentGroupId++
+        }
+        steps.push({ stepName: row.step_name, order: currentOrder })
+      }
+
+      prevEnd = Math.max(prevEnd, end)
+    }
+
+    return {
+      steps,
+      hasHooks: parseInt(hooksResult.rows[0].count) > 0,
+      hasWaits: parseInt(waitsResult.rows[0].count) > 0,
+      sourceRunId
+    }
+  })
 }
 
 export default fp(runsPlugin, { name: 'runs', dependencies: ['auth'] })

--- a/packages/workflow/test/hooks.test.ts
+++ b/packages/workflow/test/hooks.test.ts
@@ -147,12 +147,13 @@ describe('hooks', () => {
     assert.ok(body.hook)
     assert.equal(body.hook.status, 'disposed')
 
-    // Disposed hooks should not appear in list
+    // Disposed hooks should still appear when listing by runId (for run detail view)
     const listRes = await ctx.app.inject({
       method: 'GET',
       url: `/api/v1/apps/${ctx.appId}/hooks?runId=${runId}`,
       headers: { authorization: `Bearer ${ctx.apiKey}` },
     })
-    assert.equal(JSON.parse(listRes.body).data.length, 0)
+    assert.equal(JSON.parse(listRes.body).data.length, 1)
+    assert.equal(JSON.parse(listRes.body).data[0].status, 'disposed')
   })
 })

--- a/packages/workflow/test/hooks.test.ts
+++ b/packages/workflow/test/hooks.test.ts
@@ -110,6 +110,33 @@ describe('hooks', () => {
     assert.equal(body.data[0].runId, runId)
   })
 
+  it('should handle duplicate hook_created as retry (same run, same token)', async () => {
+    // Re-send hook_created with the same token and correlationId — should not conflict
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        eventType: 'hook_created',
+        correlationId: 'hook-1',
+        specVersion: 2,
+        eventData: {
+          token: hookToken,
+          ownerId: 'user-1',
+          projectId: 'proj-1',
+          environment: 'production',
+        },
+      },
+    })
+
+    assert.equal(res.statusCode, 200)
+    const body = JSON.parse(res.body)
+    // Should return the existing hook, not a conflict
+    assert.ok(body.hook)
+    assert.equal(body.hook.token, hookToken)
+    assert.equal(body.hook.status, 'pending')
+  })
+
   it('should update hook status on hook_received', async () => {
     const res = await ctx.app.inject({
       method: 'POST',

--- a/packages/workflow/test/runs.test.ts
+++ b/packages/workflow/test/runs.test.ts
@@ -103,3 +103,104 @@ describe('runs', () => {
     assert.ok(body.data.every((r: any) => r.workflowName === 'test-wf'))
   })
 })
+
+describe('workflow template', () => {
+  let ctx: TestContext
+
+  before(async () => {
+    ctx = await setupTest()
+  })
+
+  after(async () => {
+    await teardownTest(ctx)
+  })
+
+  it('should return step template from a completed run', async () => {
+    // Create a run
+    const createRes = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      payload: {
+        eventType: 'run_created',
+        specVersion: 2,
+        eventData: { deploymentId: 'v1', workflowName: 'template-wf' },
+      },
+    })
+    const templateRunId = JSON.parse(createRes.body).run.runId
+
+    // Create steps
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${templateRunId}/events`,
+      payload: { eventType: 'step_created', correlationId: 'step-a', eventData: { stepName: 'step//generatePrompts' } },
+    })
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${templateRunId}/events`,
+      payload: { eventType: 'step_started', correlationId: 'step-a' },
+    })
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${templateRunId}/events`,
+      payload: { eventType: 'step_completed', correlationId: 'step-a', eventData: { result: 'ok' } },
+    })
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${templateRunId}/events`,
+      payload: { eventType: 'step_created', correlationId: 'step-b', eventData: { stepName: 'step//generateImage' } },
+    })
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${templateRunId}/events`,
+      payload: { eventType: 'step_started', correlationId: 'step-b' },
+    })
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${templateRunId}/events`,
+      payload: { eventType: 'step_completed', correlationId: 'step-b', eventData: { result: 'ok' } },
+    })
+
+    // Complete the run
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${templateRunId}/events`,
+      payload: { eventType: 'run_completed', eventData: { output: 'done' } },
+    })
+
+    // Fetch template
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/workflows/template-wf/template?deploymentId=v1`,
+    })
+
+    assert.equal(response.statusCode, 200)
+    const body = JSON.parse(response.body)
+    assert.equal(body.sourceRunId, templateRunId)
+    assert.equal(body.steps.length, 2)
+    assert.equal(body.steps[0].stepName, 'step//generatePrompts')
+    assert.equal(body.steps[0].order, 0)
+    assert.equal(body.steps[1].stepName, 'step//generateImage')
+    assert.equal(body.steps[1].order, 1)
+  })
+
+  it('should return 404 when no completed run exists', async () => {
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/workflows/nonexistent-wf/template?deploymentId=v99`,
+    })
+
+    assert.equal(response.statusCode, 404)
+  })
+
+  it('should return template without deploymentId filter', async () => {
+    // The completed run from the previous test should be found
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/workflows/template-wf/template`,
+    })
+
+    assert.equal(response.statusCode, 200)
+    const body = JSON.parse(response.body)
+    assert.equal(body.steps.length, 2)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       postgrator:
         specifier: ^8.0.0
         version: 8.0.0
+      ulid:
+        specifier: ^3.0.2
+        version: 3.0.2
       undici:
         specifier: ^7.22.0
         version: 7.22.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "rangeStrategy": "update-lockfile",
+  "ignoreDeps": [
+    "camelcase",
+    "mysql",
+    "swagger-ui-react",
+    "leven",
+    "ora",
+    "graphiql",
+    "actions/checkout"
+  ],
+  "prHourlyLimit": 10,
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "timezone": "Europe/Rome",
+  "schedule": [
+    "* 0-6 * * 6,0"
+  ],
+  "rebaseWhen": "conflicted"
+}


### PR DESCRIPTION
## Summary

- **Workflow template API** — `GET /api/v1/apps/:appId/workflows/:workflowName/template?deploymentId=<version>` returns step structure (names, order, parallel groups) from the most recent completed run. Used by the ICC dashboard to pre-render step placeholders for in-progress runs.
- **Event idempotency** — `insertEvent()` now skips duplicate events with the same `(run_id, event_type, correlation_id)`. Prevents "Unconsumed event in event log" errors during replay caused by duplicate `wait_created`, `step_created`, and `wait_completed` events.
- **ULID run IDs for replay** — Replay endpoint now generates `wrun_` prefixed ULID IDs (matching the SDK format) instead of UUIDs.
- **Wait creation idempotency** — `wait_created` handler skips creating duplicate wait rows.
- **Hooks list shows all hooks per run** — When filtering by `runId`, disposed hooks are included (for the run detail view). Global list still excludes disposed hooks.
