### PR TITLE
workflow: add admin API for quota management

### DIFF
--- a/packages/workflow/lib/quotas.ts
+++ b/packages/workflow/lib/quotas.ts
@@ -11,10 +11,14 @@ const CACHE_TTL = 60_000 // 1 minute
 const quotaCache = new Map<number, QuotaCache>()
 const queueCounters = new Map<string, { count: number; resetAt: number }>()
 
-const DEFAULT_QUOTAS = {
+export const DEFAULT_QUOTAS = {
   maxRuns: 10_000,
   maxEventsPerRun: 100_000,
   maxQueuePerMinute: 100_000,
+}
+
+export function invalidateQuotaCache (appId: number): void {
+  quotaCache.delete(appId)
 }
 
 async function getQuotas (app: FastifyInstance, appId: number): Promise<QuotaCache> {

--- a/packages/workflow/plugins/quotas.ts
+++ b/packages/workflow/plugins/quotas.ts
@@ -1,0 +1,71 @@
+import fp from 'fastify-plugin'
+import type { FastifyInstance } from 'fastify'
+import { Forbidden, BadRequest } from '../lib/errors.ts'
+import { DEFAULT_QUOTAS, invalidateQuotaCache } from '../lib/quotas.ts'
+
+async function quotasPlugin (app: FastifyInstance): Promise<void> {
+  // Get quotas for an app (admin only)
+  app.get('/api/v1/apps/:appId/quotas', async (request) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const appId = request.appId
+
+    const result = await app.pg.query(
+      'SELECT max_runs, max_events_per_run, max_queue_per_minute FROM workflow_app_quotas WHERE application_id = $1',
+      [appId]
+    )
+
+    if (result.rows.length === 0) {
+      return {
+        maxRuns: DEFAULT_QUOTAS.maxRuns,
+        maxEventsPerRun: DEFAULT_QUOTAS.maxEventsPerRun,
+        maxQueuePerMinute: DEFAULT_QUOTAS.maxQueuePerMinute,
+        isDefault: true
+      }
+    }
+
+    return {
+      maxRuns: result.rows[0].max_runs,
+      maxEventsPerRun: result.rows[0].max_events_per_run,
+      maxQueuePerMinute: result.rows[0].max_queue_per_minute,
+      isDefault: false
+    }
+  })
+
+  // Set quotas for an app (admin only)
+  app.put('/api/v1/apps/:appId/quotas', async (request) => {
+    if (!request.isAdmin) throw new Forbidden('admin access required')
+
+    const appId = request.appId
+    const body = request.body as {
+      maxRuns?: number
+      maxEventsPerRun?: number
+      maxQueuePerMinute?: number
+    }
+
+    if (!body || (body.maxRuns === undefined && body.maxEventsPerRun === undefined && body.maxQueuePerMinute === undefined)) {
+      throw new BadRequest('at least one quota field is required: maxRuns, maxEventsPerRun, maxQueuePerMinute')
+    }
+
+    const maxRuns = body.maxRuns ?? DEFAULT_QUOTAS.maxRuns
+    const maxEventsPerRun = body.maxEventsPerRun ?? DEFAULT_QUOTAS.maxEventsPerRun
+    const maxQueuePerMinute = body.maxQueuePerMinute ?? DEFAULT_QUOTAS.maxQueuePerMinute
+
+    await app.pg.query(
+      `INSERT INTO workflow_app_quotas (application_id, max_runs, max_events_per_run, max_queue_per_minute)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (application_id) DO UPDATE SET
+         max_runs = $2,
+         max_events_per_run = $3,
+         max_queue_per_minute = $4,
+         updated_at = NOW()`,
+      [appId, maxRuns, maxEventsPerRun, maxQueuePerMinute]
+    )
+
+    invalidateQuotaCache(appId)
+
+    return { maxRuns, maxEventsPerRun, maxQueuePerMinute }
+  })
+}
+
+export default fp(quotasPlugin, { name: 'quotas', dependencies: ['auth'] })

--- a/packages/workflow/test/quotas-api.test.ts
+++ b/packages/workflow/test/quotas-api.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { setupTest, teardownTest } from './helper.ts'
+import type { TestContext } from './helper.ts'
+
+describe('quotas API', () => {
+  let ctx: TestContext
+
+  before(async () => {
+    ctx = await setupTest()
+  })
+
+  after(async () => {
+    await teardownTest(ctx)
+  })
+
+  it('should return default quotas when none are set', async () => {
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/quotas`
+    })
+
+    assert.equal(response.statusCode, 200)
+    const body = JSON.parse(response.body)
+    assert.equal(body.maxRuns, 10_000)
+    assert.equal(body.maxEventsPerRun, 100_000)
+    assert.equal(body.maxQueuePerMinute, 100_000)
+    assert.equal(body.isDefault, true)
+  })
+
+  it('should set custom quotas', async () => {
+    const response = await ctx.app.inject({
+      method: 'PUT',
+      url: `/api/v1/apps/${ctx.appId}/quotas`,
+      payload: {
+        maxRuns: 500,
+        maxEventsPerRun: 5000,
+        maxQueuePerMinute: 200
+      }
+    })
+
+    assert.equal(response.statusCode, 200)
+    const body = JSON.parse(response.body)
+    assert.equal(body.maxRuns, 500)
+    assert.equal(body.maxEventsPerRun, 5000)
+    assert.equal(body.maxQueuePerMinute, 200)
+  })
+
+  it('should return custom quotas after setting', async () => {
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/quotas`
+    })
+
+    assert.equal(response.statusCode, 200)
+    const body = JSON.parse(response.body)
+    assert.equal(body.maxRuns, 500)
+    assert.equal(body.maxEventsPerRun, 5000)
+    assert.equal(body.maxQueuePerMinute, 200)
+    assert.equal(body.isDefault, false)
+  })
+
+  it('should allow partial quota updates', async () => {
+    const response = await ctx.app.inject({
+      method: 'PUT',
+      url: `/api/v1/apps/${ctx.appId}/quotas`,
+      payload: {
+        maxRuns: 1000
+      }
+    })
+
+    assert.equal(response.statusCode, 200)
+    const body = JSON.parse(response.body)
+    assert.equal(body.maxRuns, 1000)
+    // Unspecified fields get defaults
+    assert.equal(body.maxEventsPerRun, 100_000)
+    assert.equal(body.maxQueuePerMinute, 100_000)
+  })
+
+  it('should reject empty payload', async () => {
+    const response = await ctx.app.inject({
+      method: 'PUT',
+      url: `/api/v1/apps/${ctx.appId}/quotas`,
+      payload: {}
+    })
+
+    assert.equal(response.statusCode, 400)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/apps/:appId/quotas` — returns current quotas or defaults, admin only
- Add `PUT /api/v1/apps/:appId/quotas` — set/update quotas with upsert, admin only
- Partial updates supported (unspecified fields get defaults)
- `isDefault` field in GET response indicates whether custom quotas are configured
- Cache invalidation on quota update

