### PR TITLE
Multiple wait events fix and machineId supported

### DIFF
--- a/packages/workflow/migrations/003.do.sql
+++ b/packages/workflow/migrations/003.do.sql
@@ -1,0 +1,13 @@
+-- Dedupe non-repeatable correlated events at the index level. The
+-- SELECT-then-INSERT path in plugins/events.ts can race under concurrent
+-- dispatch retries; duplicate wait_/hook_ completion events cause
+-- "Unconsumed event in event log" on SDK replay.
+
+CREATE UNIQUE INDEX idx_we_unique_correlated
+  ON workflow_events (run_id, event_type, correlation_id)
+  WHERE event_type IN (
+    'wait_created',
+    'wait_completed',
+    'hook_received',
+    'hook_disposed'
+  ) AND correlation_id IS NOT NULL;

--- a/packages/workflow/migrations/003.do.sql
+++ b/packages/workflow/migrations/003.do.sql
@@ -1,13 +1,14 @@
 -- Dedupe non-repeatable correlated events at the index level. The
 -- SELECT-then-INSERT path in plugins/events.ts can race under concurrent
--- dispatch retries; duplicate wait_/hook_ completion events cause
--- "Unconsumed event in event log" on SDK replay.
+-- dispatch retries; duplicate wait_completed events cause "Unconsumed event
+-- in event log" on SDK replay.
+--
+-- hook_received is intentionally NOT covered here: createHook async iterators
+-- legitimately produce multiple hook_received events on the same correlation_id.
 
 CREATE UNIQUE INDEX idx_we_unique_correlated
   ON workflow_events (run_id, event_type, correlation_id)
   WHERE event_type IN (
     'wait_created',
-    'wait_completed',
-    'hook_received',
-    'hook_disposed'
+    'wait_completed'
   ) AND correlation_id IS NOT NULL;

--- a/packages/workflow/migrations/003.undo.sql
+++ b/packages/workflow/migrations/003.undo.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_we_unique_correlated;

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -134,11 +134,11 @@ function formatWait (row: any) {
 // unique index on (run_id, event_type, correlation_id) for these so that
 // ON CONFLICT DO NOTHING handles duplicate inserts atomically — the
 // SELECT-then-INSERT pattern would race under concurrent dispatch retries.
+// hook_received intentionally NOT included: createHook async iterators
+// receive multiple payloads on the same correlation_id.
 const DEDUPED_EVENT_TYPES = new Set([
   'wait_created',
   'wait_completed',
-  'hook_received',
-  'hook_disposed',
 ])
 
 async function insertEvent (client: pg.PoolClient, runId: string, appId: number, body: any): Promise<any> {
@@ -150,7 +150,7 @@ async function insertEvent (client: pg.PoolClient, runId: string, appId: number,
       `INSERT INTO workflow_events (run_id, application_id, event_type, correlation_id, event_data, spec_version)
        VALUES ($1, $2, $3, $4, $5, $6)
        ON CONFLICT (run_id, event_type, correlation_id)
-         WHERE event_type IN ('wait_created', 'wait_completed', 'hook_received', 'hook_disposed')
+         WHERE event_type IN ('wait_created', 'wait_completed')
                AND correlation_id IS NOT NULL
          DO NOTHING
        RETURNING *`,

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -130,14 +130,46 @@ function formatWait (row: any) {
   }
 }
 
+// Non-repeatable correlated event types. Migration 003 enforces a partial
+// unique index on (run_id, event_type, correlation_id) for these so that
+// ON CONFLICT DO NOTHING handles duplicate inserts atomically — the
+// SELECT-then-INSERT pattern would race under concurrent dispatch retries.
+const DEDUPED_EVENT_TYPES = new Set([
+  'wait_created',
+  'wait_completed',
+  'hook_received',
+  'hook_disposed',
+])
+
 async function insertEvent (client: pg.PoolClient, runId: string, appId: number, body: any): Promise<any> {
   const correlationId = body.correlationId || null
   const eventData = body.eventData ? encodeData(body.eventData) : null
 
+  if (correlationId && DEDUPED_EVENT_TYPES.has(body.eventType)) {
+    const inserted = await client.query(
+      `INSERT INTO workflow_events (run_id, application_id, event_type, correlation_id, event_data, spec_version)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (run_id, event_type, correlation_id)
+         WHERE event_type IN ('wait_created', 'wait_completed', 'hook_received', 'hook_disposed')
+               AND correlation_id IS NOT NULL
+         DO NOTHING
+       RETURNING *`,
+      [runId, appId, body.eventType, correlationId, eventData, body.specVersion || null]
+    )
+    if (inserted.rows.length > 0) return inserted.rows[0]
+
+    const existing = await client.query(
+      `SELECT * FROM workflow_events
+       WHERE run_id = $1 AND application_id = $2 AND event_type = $3 AND correlation_id = $4
+       LIMIT 1`,
+      [runId, appId, body.eventType, correlationId]
+    )
+    return existing.rows[0]
+  }
+
   // Skip duplicate *_created events — the SDK may re-send them on retry or
-  // re-invocation. Duplicates in the event log cause "Unconsumed event" errors
-  // during replay. Only guard _created events because other event types
-  // (e.g. step_started) can legitimately repeat for step retries.
+  // re-invocation. Other event types (e.g. step_started) can legitimately
+  // repeat for step retries, so we only guard _created here.
   if (correlationId && body.eventType.endsWith('_created')) {
     const existing = await client.query(
       `SELECT id FROM workflow_events

--- a/packages/workflow/plugins/handlers.ts
+++ b/packages/workflow/plugins/handlers.ts
@@ -7,7 +7,8 @@ async function handlersPlugin (app: FastifyInstance): Promise<void> {
   app.post('/api/v1/apps/:appId/handlers', async (request, reply) => {
     const appId = request.appId
     const body = request.body as {
-      podId: string
+      podId?: string
+      machineId?: string
       deploymentVersion: string
       endpoints: {
         workflow: string
@@ -16,8 +17,9 @@ async function handlersPlugin (app: FastifyInstance): Promise<void> {
       }
     }
 
-    if (!body.podId || !body.deploymentVersion || !body.endpoints) {
-      throw new BadRequest('podId, deploymentVersion, and endpoints are required')
+    const machineId = body.podId ?? body.machineId
+    if (!machineId || !body.deploymentVersion || !body.endpoints) {
+      throw new BadRequest('podId (or machineId), deploymentVersion, and endpoints are required')
     }
 
     await app.pg.query(
@@ -29,7 +31,7 @@ async function handlersPlugin (app: FastifyInstance): Promise<void> {
          step_url = $5,
          webhook_url = $6,
          last_heartbeat = NOW()`,
-      [appId, body.podId, body.deploymentVersion,
+      [appId, machineId, body.deploymentVersion,
         body.endpoints.workflow, body.endpoints.step, body.endpoints.webhook]
     )
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - 'packages/*'
   - 'e2e-v5'
   - 'e2e-v4'
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
## Summary

Fixes two issues surfaced while running the birthday-card-generator example against the local Platformatic cluster:

1. **Duplicate `wait_*` events crash workflow replay.** The SELECT-then-INSERT in `plugins/events.ts` races under concurrent dispatch retries, producing two `wait_created` / `wait_completed` rows for the same `correlation_id`. The SDK then fails replay with `Unconsumed event in event log` and the run dead-letters.

2. **ICC handler registration rejected.** ICC PR [icc3#788](https://github.com/platformatic/icc3/pull/788) renamed `podId` → `machineId` in the body it POSTs to `/api/v1/apps/:appId/handlers`. The workflow service still required `podId` and 400'd every registration, so `workflow_queue_handlers` stayed empty and queue messages had nowhere to dispatch.

## Changes

- `migrations/003.do.sql` — partial unique index `(run_id, event_type, correlation_id)` for `wait_created` and `wait_completed`. Intentionally **does not** cover `hook_*`: `createHook` async iterators legitimately produce multiple `hook_received` events on the same correlation id.
- `plugins/events.ts` — `insertEvent` uses `INSERT … ON CONFLICT DO NOTHING` for the deduped types and falls back to a SELECT when the conflict fires, so callers still receive a row.
- `plugins/handlers.ts` — `/handlers` accepts either `podId` (legacy) or `machineId` (post-#788), keeping the existing contract working while letting current ICC clients register.
