### PR TITLE
flaky test fix

### DIFF
--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -233,16 +233,39 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
           const eventData = body.eventData || {}
           const input = encodeData(eventData.input)
 
-          await client.query(
+          // Idempotent: the SDK retries this endpoint on transient errors
+          // (network blip, timeout, 5xx). A duplicate POST for the same runId
+          // must not 500 on the workflow_runs unique constraint — return the
+          // existing run state instead. Mirrors the run_started handler's
+          // existence-check pattern, just via an atomic upsert.
+          const inserted = await client.query(
             `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, input, execution_context, spec_version)
-             VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7)`,
+             VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7)
+             ON CONFLICT (id) DO NOTHING
+             RETURNING id`,
             [runId, appId, eventData.workflowName, eventData.deploymentId, input, eventData.executionContext || null, body.specVersion || null]
           )
 
-          const eventRow = await insertEvent(client, runId, appId, body)
+          // Only emit the run_created event row when we actually created the
+          // run. The event log has no unique key on (run_id, event_type) so an
+          // unconditional insert would leave a duplicate run_created in the
+          // log on each retry, which the SDK consumer would reject on replay.
+          let eventRow: any
+          if (inserted.rows.length > 0) {
+            eventRow = await insertEvent(client, runId, appId, body)
+          } else {
+            const existing = await client.query(
+              `SELECT * FROM workflow_events
+               WHERE run_id = $1 AND application_id = $2 AND event_type = 'run_created'
+               ORDER BY id ASC LIMIT 1`,
+              [runId, appId]
+            )
+            eventRow = existing.rows[0] || null
+          }
+
           const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [runId])).rows[0]
 
-          result = { event: formatEvent(eventRow, resolveData), run: formatRun(runRow, resolveData) }
+          result = { event: eventRow ? formatEvent(eventRow, resolveData) : null, run: formatRun(runRow, resolveData) }
           break
         }
 

--- a/packages/workflow/test/events.test.ts
+++ b/packages/workflow/test/events.test.ts
@@ -42,6 +42,54 @@ describe('events', () => {
     assert.ok(body.run.runId)
   })
 
+  it('should be idempotent on duplicate run_created for the same runId', async () => {
+    // The SDK retries the trigger endpoint on transient errors. A second
+    // POST for the same runId must return 200 (with the existing run state),
+    // not 500 from the workflow_runs unique constraint, and must not append
+    // a duplicate run_created event to the log.
+    const runId = `wrun_idempotent_${randomBytes(8).toString('hex')}`
+    const payload = {
+      eventType: 'run_created',
+      specVersion: 2,
+      eventData: {
+        deploymentId: 'v1.0.0',
+        workflowName: 'idempotent-test',
+        input: { n: 1 },
+      },
+    }
+
+    const first = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload,
+    })
+    assert.equal(first.statusCode, 200)
+    const firstBody = JSON.parse(first.body)
+    assert.equal(firstBody.run.runId, runId)
+
+    const second = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload,
+    })
+    assert.equal(second.statusCode, 200)
+    const secondBody = JSON.parse(second.body)
+    assert.equal(secondBody.run.runId, runId)
+
+    // Exactly one run_created event in the log, no duplicates.
+    const eventsRes = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+    })
+    assert.equal(eventsRes.statusCode, 200)
+    const events = JSON.parse(eventsRes.body)
+    const runCreatedEvents = events.data.filter((e: any) => e.eventType === 'run_created')
+    assert.equal(runCreatedEvents.length, 1, 'expected exactly one run_created event')
+  })
+
   it('should handle full run lifecycle', async () => {
     // Create run
     const createRes = await ctx.app.inject({


### PR DESCRIPTION
Fixes the `run_created` race that surfaced as a flaky `sleepWithSequentialSteps` e2e failure 

## Root cause

`events.ts` `run_created` handler did a plain `INSERT INTO workflow_runs` with no `ON CONFLICT` clause. Any SDK retry of the trigger call (transient network error, 5xx, timeout) hits the `workflow_runs_pkey` unique constraint and the request fails with 500:

```
HTTP 500: duplicate key value violates unique constraint "workflow_runs_pkey"
```

The matching `run_started` handler already had an existence check; `run_created` was the odd one out.

## Fix

1. `workflow_runs` insert -> `ON CONFLICT (id) DO NOTHING RETURNING id`. Race losers (retries) get the existing row instead of a 500.
2. Only emit the `run_created` event row when the run insert actually created the run. Otherwise the log gets a duplicate `run_created` per retry, which the SDK consumer would reject on replay.

