### PR TITLE
feat: Fix distributed workflow execution reliability.

### DIFF
--- a/PLATFORMATIC-WORLD-DESIGN.md
+++ b/PLATFORMATIC-WORLD-DESIGN.md
@@ -236,7 +236,7 @@ Each event type is processed in a single database transaction. The response incl
 
 ```
 GET    /api/v1/apps/:appId/runs/:runId/events
-  Query: ?order=asc&limit=100&cursor=0&resolveData=none
+  Query: ?sortOrder=asc&limit=100&cursor=0&resolveData=none
   → Returns paginated events for the run (used during replay)
 
 GET    /api/v1/apps/:appId/events/by-correlation
@@ -672,7 +672,7 @@ sequenceDiagram
     participant WFS as Workflow Service
 
     Pod->>WFS: world.queue - wkf_step_myStep, workflowRunId, stepId
-    Note over WFS: 1. Extract deploymentId from message<br/>2. Find registered pod for that deploymentId<br/>3. POST to pod queue handler endpoint
+    Note over WFS: 1. Extract deploymentId from message<br/>2. Find registered endpoint for that deploymentId<br/>3. POST to queue handler endpoint
     WFS->>Pod: Dispatch step to same version that started the run
     Note over Pod: Handler executes the step<br/>Step result stored via WF Service API
     Pod->>WFS: world.queue - wkf_workflow_myWorkflow, runId
@@ -693,9 +693,9 @@ The queue router (`queue/router.ts`) applies version-pinning:
    - `__wkf_workflow_*` → workflow handler URL
    - Other → webhook handler URL
 
-4. **Select target pod:** Query `workflow_queue_handlers` for the matching `deployment_version` and `application_id`. When multiple pods exist for the same version, the router picks one.
+4. **Select target endpoint:** Query `workflow_queue_handlers` for the matching `deployment_version` and `application_id`, deduplicate exact URLs for the queue type, and pick one URL.
 
-5. **Deliver** via HTTP POST to the target pod's registered queue handler endpoint.
+5. **Deliver** via HTTP POST to the selected queue handler endpoint. With ICC's current Service URLs, Kubernetes selects the receiving pod; the selected registration does not identify the executing pod.
 
 ### 8.3 Deferred Message Delivery
 
@@ -747,7 +747,7 @@ graph LR
 ```
 
 - **Deferred → Pending:** The leader executor promotes deferred messages when `deliver_at <= NOW()` (triggered by timer, not polling). Immediate messages (`delaySeconds == 0`) go directly to Pending.
-- **Pending → Dispatched:** The service routes the message to the correct pod and POSTs it.
+- **Pending → Dispatched:** The service routes the message to the correct deployment version's endpoint and POSTs it.
 - **Dispatched → Delivered:** The pod processes the message and returns 200.
 - **Dispatched → Retrying:** The pod returns an error or is unreachable. The service retries with exponential backoff (1s, 2s, 4s, 8s, up to 60s). Default max retries: 10.
 - **Retrying → Dead:** After exhausting retries, the message is moved to dead-letter status. Dead-lettered messages can be retried manually via `POST /dead-letters/:messageId/retry`.
@@ -1090,7 +1090,7 @@ This is essential because **apps typically run in their own namespaces** (e.g. `
 
 A ClusterIP Service must exist with the `app.kubernetes.io/name` label matching the pod. ICC uses this service to construct the dispatch URL. The service must expose the app port (default 3042).
 
-**The world client does NOT register handlers in K8s** — it detects the K8s environment via the service account token and skips registration in `start()`. This avoids creating duplicate handlers with conflicting URLs (one from ICC with FQDN, one from the world client with localhost). The dispatcher picks randomly among matching handlers, so a duplicate localhost entry would cause ~50% of cross-namespace dispatches to fail.
+**The world client does NOT register handlers in K8s** — it detects the K8s environment via the service account token and skips registration in `start()`. This avoids adding an unreachable localhost URL alongside ICC's Service URL. The router deduplicates exact URLs before selecting a destination, but distinct conflicting URLs remain independently selectable.
 
 ### 11.3 Draining Checks (Three-Phase Model)
 
@@ -1307,4 +1307,3 @@ For testing workflows with skew protection in a local K8s cluster, use the Desk 
 | Auth | N/A | Database user | Vercel tokens | **K8s service account token (multi-tenant) / none (single-tenant)** |
 | Quotas | N/A | N/A | Vercel limits | **Per-app configurable** |
 | Infrastructure | None | PostgreSQL | Vercel | **K8s + ICC + Workflow Service + PostgreSQL** |
-

--- a/README.md
+++ b/README.md
@@ -358,8 +358,10 @@ The queue router pins messages to deployment versions:
 
 1. Each message carries a `deployment_version` from the run that created it
 2. The router looks up registered handlers for that version
-3. Messages are dispatched via HTTP POST to the correct pod
+3. The router deduplicates exact endpoint URLs and selects one for HTTP dispatch
 4. If a version is expired, messages are rejected
+
+In Kubernetes, ICC currently registers Service URLs. The selected URL therefore pins execution to a deployment version, not to a specific pod; Kubernetes chooses the backend for the service connection.
 
 ### Deferred Delivery
 

--- a/packages/workflow/migrations/005.do.sql
+++ b/packages/workflow/migrations/005.do.sql
@@ -1,0 +1,36 @@
+LOCK TABLE workflow_stream_chunks IN ACCESS EXCLUSIVE MODE;
+
+WITH ranked_chunks AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY application_id, run_id, stream_name
+           ORDER BY chunk_index, id
+         )::integer - 1 AS new_chunk_index
+  FROM workflow_stream_chunks
+  WHERE is_closed = FALSE
+)
+UPDATE workflow_stream_chunks AS chunks
+SET chunk_index = ranked_chunks.new_chunk_index
+FROM ranked_chunks
+WHERE chunks.id = ranked_chunks.id;
+
+WITH ranked_closes AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY application_id, run_id, stream_name
+           ORDER BY id
+         ) AS close_number
+  FROM workflow_stream_chunks
+  WHERE is_closed = TRUE
+)
+DELETE FROM workflow_stream_chunks AS chunks
+USING ranked_closes
+WHERE chunks.id = ranked_closes.id
+  AND ranked_closes.close_number > 1;
+
+UPDATE workflow_stream_chunks
+SET chunk_index = -1
+WHERE is_closed = TRUE;
+
+CREATE UNIQUE INDEX idx_wsc_unique_chunk
+  ON workflow_stream_chunks (application_id, run_id, stream_name, chunk_index);

--- a/packages/workflow/migrations/005.undo.sql
+++ b/packages/workflow/migrations/005.undo.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_wsc_unique_chunk;

--- a/packages/workflow/migrations/006.do.sql
+++ b/packages/workflow/migrations/006.do.sql
@@ -1,0 +1,5 @@
+ALTER TABLE workflow_queue_messages
+  ADD COLUMN last_failure JSONB,
+  ADD COLUMN dead_at TIMESTAMPTZ,
+  ADD COLUMN terminalized_at TIMESTAMPTZ,
+  ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/packages/workflow/migrations/006.do.sql
+++ b/packages/workflow/migrations/006.do.sql
@@ -1,5 +1,5 @@
 ALTER TABLE workflow_queue_messages
   ADD COLUMN last_failure JSONB,
   ADD COLUMN dead_at TIMESTAMPTZ,
-  ADD COLUMN terminalized_at TIMESTAMPTZ,
+  ADD COLUMN failure_finalized_at TIMESTAMPTZ,
   ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();

--- a/packages/workflow/migrations/006.undo.sql
+++ b/packages/workflow/migrations/006.undo.sql
@@ -1,5 +1,5 @@
 ALTER TABLE workflow_queue_messages
   DROP COLUMN updated_at,
-  DROP COLUMN terminalized_at,
+  DROP COLUMN failure_finalized_at,
   DROP COLUMN dead_at,
   DROP COLUMN last_failure;

--- a/packages/workflow/migrations/006.undo.sql
+++ b/packages/workflow/migrations/006.undo.sql
@@ -1,0 +1,5 @@
+ALTER TABLE workflow_queue_messages
+  DROP COLUMN updated_at,
+  DROP COLUMN terminalized_at,
+  DROP COLUMN dead_at,
+  DROP COLUMN last_failure;

--- a/packages/workflow/plugins/dead-letters.ts
+++ b/packages/workflow/plugins/dead-letters.ts
@@ -24,7 +24,7 @@ async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
 
     const result = await app.pg.query(
       `SELECT id, idempotency_key, queue_name, run_id, deployment_version, payload, attempts,
-              last_failure, dead_at, terminalized_at, created_at
+              last_failure, dead_at, failure_finalized_at, created_at
        FROM workflow_queue_messages
        WHERE ${conditions.join(' AND ')}
        ORDER BY created_at DESC
@@ -43,7 +43,7 @@ async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
       attempts: row.attempts,
       lastFailure: row.last_failure,
       deadAt: row.dead_at,
-      terminalizedAt: row.terminalized_at,
+      failureFinalizedAt: row.failure_finalized_at,
       createdAt: row.created_at,
     }))
     const nextCursor = hasMore ? String(offset + limit) : null
@@ -67,13 +67,13 @@ async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
          SET status = 'pending', attempts = 0, next_retry_at = NULL,
              dead_at = NULL, updated_at = NOW()
          WHERE id = $1 AND application_id = $2 AND status = 'dead'
-           AND terminalized_at IS NULL
+           AND failure_finalized_at IS NULL
          RETURNING id`,
         [numericId, appId]
       )
 
       if (result.rows.length === 0) {
-        throw new BadRequest('message not found, not dead, or already terminalized')
+        throw new BadRequest('message not found, not dead, or failure already finalized')
       }
 
       await client.query("SELECT pg_notify('deferred_messages', '{}')")

--- a/packages/workflow/plugins/dead-letters.ts
+++ b/packages/workflow/plugins/dead-letters.ts
@@ -23,7 +23,8 @@ async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
     params.push(offset)
 
     const result = await app.pg.query(
-      `SELECT id, idempotency_key, queue_name, run_id, deployment_version, payload, attempts, created_at
+      `SELECT id, idempotency_key, queue_name, run_id, deployment_version, payload, attempts,
+              last_failure, dead_at, terminalized_at, created_at
        FROM workflow_queue_messages
        WHERE ${conditions.join(' AND ')}
        ORDER BY created_at DESC
@@ -40,6 +41,9 @@ async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
       deploymentVersion: row.deployment_version,
       payload: row.payload,
       attempts: row.attempts,
+      lastFailure: row.last_failure,
+      deadAt: row.dead_at,
+      terminalizedAt: row.terminalized_at,
       createdAt: row.created_at,
     }))
     const nextCursor = hasMore ? String(offset + limit) : null
@@ -55,19 +59,32 @@ async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
 
     if (isNaN(numericId)) throw new BadRequest('invalid messageId')
 
-    const result = await app.pg.query(
-      `UPDATE workflow_queue_messages
-       SET status = 'pending', attempts = 0, next_retry_at = NULL
-       WHERE id = $1 AND application_id = $2 AND status = 'dead'
-       RETURNING id`,
-      [numericId, appId]
-    )
+    const client = await app.pg.connect()
+    try {
+      await client.query('BEGIN')
+      const result = await client.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'pending', attempts = 0, next_retry_at = NULL,
+             dead_at = NULL, updated_at = NOW()
+         WHERE id = $1 AND application_id = $2 AND status = 'dead'
+           AND terminalized_at IS NULL
+         RETURNING id`,
+        [numericId, appId]
+      )
 
-    if (result.rows.length === 0) {
-      throw new BadRequest('message not found or not in dead state')
+      if (result.rows.length === 0) {
+        throw new BadRequest('message not found, not dead, or already terminalized')
+      }
+
+      await client.query("SELECT pg_notify('deferred_messages', '{}')")
+      await client.query('COMMIT')
+      return { retried: true, messageId: `msg_${numericId}` }
+    } catch (err) {
+      try { await client.query('ROLLBACK') } catch {}
+      throw err
+    } finally {
+      client.release()
     }
-
-    return { retried: true, messageId: `msg_${numericId}` }
   })
 }
 

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -817,11 +817,13 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
     const appId = request.appId
     const limit = Math.min(parseInt(query.limit || '100', 10), 1000)
     const sortOrder = query.sortOrder === 'desc' ? 'DESC' : 'ASC'
-    const cursor = query.cursor ? parseInt(query.cursor, 10) : 0
+    const cursor = query.cursor ? parseInt(query.cursor, 10) : null
+    const cursorOperator = sortOrder === 'DESC' ? '<' : '>'
 
     const result = await app.pg.query(
       `SELECT * FROM workflow_events
-       WHERE run_id = $1 AND application_id = $2 AND id > $3
+       WHERE run_id = $1 AND application_id = $2
+         AND ($3::int IS NULL OR id ${cursorOperator} $3)
        ORDER BY id ${sortOrder}
        LIMIT $4`,
       [runId, appId, cursor, limit + 1]
@@ -829,29 +831,38 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
 
     const hasMore = result.rows.length > limit
     const data = result.rows.slice(0, limit).map(row => formatEvent(row, query.resolveData))
-    const nextCursor = hasMore && data.length > 0 ? String(result.rows[limit - 1].id) : null
+    const nextCursor = data.length > 0 ? data[data.length - 1].eventId : query.cursor ?? null
 
     return { data, cursor: nextCursor, hasMore }
   })
 
   // List events by correlation ID
   app.get('/api/v1/apps/:appId/events/by-correlation', async (request) => {
-    const query = request.query as { correlationId: string; limit?: string; cursor?: string; resolveData?: string }
+    const query = request.query as {
+      correlationId: string
+      limit?: string
+      cursor?: string
+      sortOrder?: string
+      resolveData?: string
+    }
     const appId = request.appId
     const limit = Math.min(parseInt(query.limit || '100', 10), 1000)
-    const cursor = query.cursor ? parseInt(query.cursor, 10) : 0
+    const sortOrder = query.sortOrder === 'desc' ? 'DESC' : 'ASC'
+    const cursor = query.cursor ? parseInt(query.cursor, 10) : null
+    const cursorOperator = sortOrder === 'DESC' ? '<' : '>'
 
     const result = await app.pg.query(
       `SELECT * FROM workflow_events
-       WHERE application_id = $1 AND correlation_id = $2 AND id > $3
-       ORDER BY id ASC
+       WHERE application_id = $1 AND correlation_id = $2
+         AND ($3::int IS NULL OR id ${cursorOperator} $3)
+       ORDER BY id ${sortOrder}
        LIMIT $4`,
       [appId, query.correlationId, cursor, limit + 1]
     )
 
     const hasMore = result.rows.length > limit
     const data = result.rows.slice(0, limit).map(row => formatEvent(row, query.resolveData))
-    const nextCursor = hasMore && data.length > 0 ? String(result.rows[limit - 1].id) : null
+    const nextCursor = data.length > 0 ? data[data.length - 1].eventId : query.cursor ?? null
 
     return { data, cursor: nextCursor, hasMore }
   })

--- a/packages/workflow/plugins/streams.ts
+++ b/packages/workflow/plugins/streams.ts
@@ -62,6 +62,7 @@ async function streamsPlugin (app: FastifyInstance): Promise<void> {
       if (isDone) {
         hs.closed = true
       } else if (isMulti) {
+        if (hs.closed) throw new BadRequest('stream is already closed')
         const chunks = request.body as any[]
         if (!Array.isArray(chunks)) throw new BadRequest('body must be an array for multi-write')
         for (const chunk of chunks) {
@@ -69,6 +70,7 @@ async function streamsPlugin (app: FastifyInstance): Promise<void> {
           hs.chunks.push(data)
         }
       } else {
+        if (hs.closed) throw new BadRequest('stream is already closed')
         const body = request.body as any
         const data = typeof body === 'string'
           ? Buffer.from(body, 'utf-8')
@@ -83,67 +85,75 @@ async function streamsPlugin (app: FastifyInstance): Promise<void> {
       return
     }
 
-    if (isDone) {
-      await app.pg.query(
-        `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data, is_closed)
-         VALUES ($1, $2, $3, -1, $4, TRUE)
-         ON CONFLICT DO NOTHING`,
-        [name, runId, appId, Buffer.alloc(0)]
+    const chunks = isMulti ? request.body as any[] : null
+    if (isMulti && !Array.isArray(chunks)) throw new BadRequest('body must be an array for multi-write')
+
+    const client = await app.pg.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(
+        `SELECT pg_advisory_xact_lock(
+           hashtextextended(json_build_array($1::integer, $2::text, $3::text)::text, 0)
+         )`,
+        [appId, runId, name]
       )
-      await notifyStream(name)
-      reply.code(204)
-      return
-    }
 
-    if (isMulti) {
-      const chunks = request.body as any[]
-      if (!Array.isArray(chunks)) throw new BadRequest('body must be an array for multi-write')
-
-      const maxResult = await app.pg.query(
-        `SELECT COALESCE(MAX(chunk_index), -1) as max_idx FROM workflow_stream_chunks
-         WHERE stream_name = $1 AND run_id = $2 AND application_id = $3 AND is_closed = FALSE`,
+      const closedResult = await client.query(
+        `SELECT 1 FROM workflow_stream_chunks
+         WHERE stream_name = $1 AND run_id = $2 AND application_id = $3 AND is_closed = TRUE
+         LIMIT 1`,
         [name, runId, appId]
       )
-      let idx = maxResult.rows[0].max_idx + 1
 
-      const client = await app.pg.connect()
-      try {
-        await client.query('BEGIN')
-        for (const chunk of chunks) {
-          const data = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : Buffer.from(chunk.data || chunk, 'base64')
+      if (isDone) {
+        if (closedResult.rows.length === 0) {
+          await client.query(
+            `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data, is_closed)
+             VALUES ($1, $2, $3, -1, $4, TRUE)`,
+            [name, runId, appId, Buffer.alloc(0)]
+          )
+        }
+      } else {
+        if (closedResult.rows.length > 0) throw new BadRequest('stream is already closed')
+
+        const maxResult = await client.query(
+          `SELECT COALESCE(MAX(chunk_index), -1) AS max_idx FROM workflow_stream_chunks
+           WHERE stream_name = $1 AND run_id = $2 AND application_id = $3 AND is_closed = FALSE`,
+          [name, runId, appId]
+        )
+        let idx = maxResult.rows[0].max_idx + 1
+
+        if (chunks) {
+          for (const chunk of chunks) {
+            const data = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : Buffer.from(chunk.data || chunk, 'base64')
+            await client.query(
+              `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data)
+               VALUES ($1, $2, $3, $4, $5)`,
+              [name, runId, appId, idx++, data]
+            )
+          }
+        } else {
+          const body = request.body as any
+          const data = typeof body === 'string'
+            ? Buffer.from(body, 'utf-8')
+            : Buffer.isBuffer(body)
+              ? body
+              : Buffer.from(body.data || JSON.stringify(body), 'base64')
+
           await client.query(
             `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data)
              VALUES ($1, $2, $3, $4, $5)`,
-            [name, runId, appId, idx++, data]
+            [name, runId, appId, idx, data]
           )
         }
-        await client.query('COMMIT')
-      } catch (err) {
-        await client.query('ROLLBACK')
-        throw err
-      } finally {
-        client.release()
       }
-    } else {
-      const body = request.body as any
-      const data = typeof body === 'string'
-        ? Buffer.from(body, 'utf-8')
-        : Buffer.isBuffer(body)
-          ? body
-          : Buffer.from(body.data || JSON.stringify(body), 'base64')
 
-      const maxResult = await app.pg.query(
-        `SELECT COALESCE(MAX(chunk_index), -1) as max_idx FROM workflow_stream_chunks
-         WHERE stream_name = $1 AND run_id = $2 AND application_id = $3 AND is_closed = FALSE`,
-        [name, runId, appId]
-      )
-      const idx = maxResult.rows[0].max_idx + 1
-
-      await app.pg.query(
-        `INSERT INTO workflow_stream_chunks (stream_name, run_id, application_id, chunk_index, data)
-         VALUES ($1, $2, $3, $4, $5)`,
-        [name, runId, appId, idx, data]
-      )
+      await client.query('COMMIT')
+    } catch (err) {
+      await client.query('ROLLBACK')
+      throw err
+    } finally {
+      client.release()
     }
 
     await notifyStream(name)
@@ -205,17 +215,27 @@ async function streamsPlugin (app: FastifyInstance): Promise<void> {
       }
 
       let nextIndex = startIndex
-      let done = false
 
-      async function flush (): Promise<void> {
+      async function flush (): Promise<boolean> {
         const result = await app.pg.query(
-          `SELECT data, chunk_index FROM workflow_stream_chunks
-           WHERE stream_name = $1 AND application_id = $2 AND chunk_index >= $3 AND is_closed = FALSE
-           ORDER BY chunk_index ASC`,
+          `WITH stream_state AS (
+             SELECT EXISTS (
+               SELECT 1 FROM workflow_stream_chunks
+               WHERE stream_name = $1 AND application_id = $2 AND is_closed = TRUE
+             ) AS is_closed
+           ), chunks AS (
+             SELECT data, chunk_index FROM workflow_stream_chunks
+             WHERE stream_name = $1 AND application_id = $2 AND chunk_index >= $3 AND is_closed = FALSE
+           )
+           SELECT chunks.data, chunks.chunk_index, stream_state.is_closed
+           FROM stream_state
+           LEFT JOIN chunks ON TRUE
+           ORDER BY chunks.chunk_index ASC NULLS LAST`,
           [name, appId, nextIndex]
         )
 
         for (const row of result.rows) {
+          if (row.chunk_index === null) continue
           const buf = row.data as Buffer
           if (buf.byteLength > 0) {
             reply.raw.write(buf)
@@ -223,41 +243,58 @@ async function streamsPlugin (app: FastifyInstance): Promise<void> {
           nextIndex = row.chunk_index + 1
         }
 
-        const closedResult = await app.pg.query(
-          `SELECT 1 FROM workflow_stream_chunks
-           WHERE stream_name = $1 AND application_id = $2 AND is_closed = TRUE
-           LIMIT 1`,
-          [name, appId]
-        )
-
-        if (closedResult.rows.length > 0) {
-          done = true
+        const done = result.rows[0].is_closed as boolean
+        if (done) {
           reply.raw.end()
         }
+        return done
       }
 
-      // Flush any existing chunks first
-      await flush()
-      if (done) return reply
-
-      // Wait for NOTIFY events to flush new chunks
       return new Promise((resolve) => {
-        const onUpdate = async () => {
-          if (done) return
-          await flush()
-          if (done) {
-            streamEvents.removeListener(name, onUpdate)
-            resolve(reply)
-          }
-        }
-        streamEvents.on(name, onUpdate)
+        let done = false
+        let flushing = false
+        let pending = false
 
-        // Clean up if client disconnects
-        request.raw.on('close', () => {
+        function cleanup (): void {
+          if (done) return
           done = true
           streamEvents.removeListener(name, onUpdate)
+          request.raw.removeListener('close', onClose)
           resolve(reply)
-        })
+        }
+
+        function onClose (): void {
+          cleanup()
+        }
+
+        function onUpdate (): void {
+          if (done) return
+          if (flushing) {
+            pending = true
+            return
+          }
+
+          flushing = true
+          const drain = async () => {
+            do {
+              pending = false
+              if (await flush()) cleanup()
+            } while (pending && !done)
+          }
+          const finish = () => {
+            flushing = false
+            if (pending && !done) onUpdate()
+          }
+          drain().then(finish, err => {
+            cleanup()
+            reply.raw.destroy(err as Error)
+            finish()
+          })
+        }
+
+        streamEvents.on(name, onUpdate)
+        request.raw.on('close', onClose)
+        onUpdate()
       })
     }
 

--- a/packages/workflow/queue/dispatcher.ts
+++ b/packages/workflow/queue/dispatcher.ts
@@ -5,6 +5,12 @@ export interface DispatchResult {
   success: boolean
   timeoutSeconds?: number
   statusCode: number
+  error?: DispatchError
+}
+
+export interface DispatchError {
+  code: string
+  message: string
 }
 
 export interface DispatchInput {
@@ -15,6 +21,32 @@ export interface DispatchInput {
   payloadBytes: Buffer | null
   payloadEncoding: 'json' | 'cbor'
   attempt: number
+}
+
+const ERROR_CODE_LIMIT = 64
+const ERROR_MESSAGE_LIMIT = 512
+
+function dispatchError (code: string, message: string): DispatchError {
+  return {
+    code: code.toUpperCase().replace(/[^A-Z0-9_]/g, '_').slice(0, ERROR_CODE_LIMIT) || 'DISPATCH_ERROR',
+    message: message.slice(0, ERROR_MESSAGE_LIMIT),
+  }
+}
+
+function requestError (err: unknown): DispatchError {
+  const code = typeof err === 'object' && err !== null && 'code' in err && typeof err.code === 'string'
+    ? err.code
+    : 'DISPATCH_ERROR'
+
+  switch (code) {
+    case 'UND_ERR_HEADERS_TIMEOUT': return dispatchError(code, 'Target response headers timed out')
+    case 'UND_ERR_BODY_TIMEOUT': return dispatchError(code, 'Target response body timed out')
+    case 'UND_ERR_CONNECT_TIMEOUT': return dispatchError(code, 'Target connection timed out')
+    case 'ECONNREFUSED': return dispatchError(code, 'Target connection was refused')
+    case 'ECONNRESET': return dispatchError(code, 'Target connection was reset')
+    case 'ENOTFOUND': return dispatchError(code, 'Target host was not found')
+    default: return dispatchError(code, 'Target request failed')
+  }
 }
 
 export async function dispatchMessage (input: DispatchInput): Promise<DispatchResult> {
@@ -77,8 +109,12 @@ export async function dispatchMessage (input: DispatchInput): Promise<DispatchRe
     }
 
     await response.body.dump()
-    return { success: false, statusCode }
-  } catch {
-    return { success: false, statusCode: 0 }
+    return {
+      success: false,
+      statusCode,
+      error: dispatchError(`HTTP_${statusCode}`, `Target returned HTTP ${statusCode}`),
+    }
+  } catch (err) {
+    return { success: false, statusCode: 0, error: requestError(err) }
   }
 }

--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -196,7 +196,7 @@ async function failBackgroundStep (client: pg.PoolClient, msg: any, failure: Fai
   return true
 }
 
-async function terminalize (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
+async function finalizeFailure (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
   // v5 dispatches background steps through the workflow queue, while v4 uses
   // a dedicated step queue. The payload is the authoritative discriminator.
   if (await failBackgroundStep(client, msg, failure)) return
@@ -207,7 +207,7 @@ async function terminalize (client: pg.PoolClient, msg: any, failure: FailureDet
   }
 }
 
-async function lockRunForTerminalization (client: pg.PoolClient, msg: any): Promise<void> {
+async function lockRunForFailureFinalization (client: pg.PoolClient, msg: any): Promise<void> {
   if (!msg.run_id) return
   if (msg.queue_name.startsWith('__wkf_workflow_')) await ensureRunForWorkflowDelivery(client, msg)
   await client.query(
@@ -318,7 +318,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
   async function executeOnce (): Promise<void> {
     const client = await pool.connect()
     try {
-      // 1. Terminalize rows left at the retry ceiling by older pollers.
+      // 1. Finalize failures for rows left at the retry ceiling by older pollers.
       const exhausted = await client.query(
         `SELECT * FROM workflow_queue_messages
          WHERE status = 'failed' AND attempts >= 10
@@ -516,16 +516,16 @@ export async function handleExhaustedMessage (client: pg.PoolClient, msg: any): 
 
   await client.query('BEGIN')
   try {
-    await lockRunForTerminalization(client, msg)
+    await lockRunForFailureFinalization(client, msg)
     const updated = await client.query(
       `UPDATE workflow_queue_messages
-       SET status = 'dead', last_failure = $4, dead_at = NOW(), terminalized_at = NOW(),
+       SET status = 'dead', last_failure = $4, dead_at = NOW(), failure_finalized_at = NOW(),
            next_retry_at = NULL, updated_at = NOW()
        WHERE id = $1 AND application_id = $2 AND status = 'failed' AND attempts = $3
        RETURNING id`,
       [msg.id, msg.application_id, msg.attempts, failure]
     )
-    if (updated.rows.length > 0) await terminalize(client, msg, failure)
+    if (updated.rows.length > 0) await finalizeFailure(client, msg, failure)
     await client.query('COMMIT')
   } catch (err) {
     await client.query('ROLLBACK')
@@ -545,16 +545,16 @@ export async function handleNoRoute (client: pg.PoolClient, msg: any): Promise<v
   await client.query('BEGIN')
   try {
     if (isMaxAttempts(attempts)) {
-      await lockRunForTerminalization(client, msg)
+      await lockRunForFailureFinalization(client, msg)
       const updated = await client.query(
         `UPDATE workflow_queue_messages
          SET status = 'dead', attempts = $4, last_failure = $5, dead_at = NOW(),
-             terminalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
+             failure_finalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
          WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
          RETURNING id`,
         [msg.id, msg.application_id, msg.attempts, attempts, failure]
       )
-      if (updated.rows.length > 0) await terminalize(client, msg, failure)
+      if (updated.rows.length > 0) await finalizeFailure(client, msg, failure)
     } else {
       const delay = getRetryDelay(attempts)
       await client.query(
@@ -620,16 +620,16 @@ export async function handleDispatchResult (
       const failure = failureDetail(msg, attempts, error.code, error.message, target, result.statusCode)
 
       if (isMaxAttempts(attempts)) {
-        await lockRunForTerminalization(client, msg)
+        await lockRunForFailureFinalization(client, msg)
         const updated = await client.query(
           `UPDATE workflow_queue_messages
            SET status = 'dead', attempts = $4, last_failure = $5, dead_at = NOW(),
-               terminalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
+               failure_finalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
            WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
            RETURNING id`,
           [msg.id, msg.application_id, msg.attempts, attempts, failure]
         )
-        if (updated.rows.length > 0) await terminalize(client, msg, failure)
+        if (updated.rows.length > 0) await finalizeFailure(client, msg, failure)
       } else {
         const delay = getRetryDelay(attempts)
         await client.query(

--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -1,5 +1,6 @@
 import pg from 'pg'
 import createLeaderElector from '@platformatic/leader'
+import { decode, encode } from 'cbor-x'
 import { routeMessage } from './router.ts'
 import { dispatchMessage, type DispatchResult } from './dispatcher.ts'
 import { getRetryDelay, isMaxAttempts } from './retry.ts'
@@ -21,6 +22,199 @@ const DEFERRED_CHANNEL = 'deferred_messages'
 // task (see processMessage), so a single slow/hung handler can no longer block
 // the poll loop; this cap just bounds concurrency and the in-flight set size.
 const MAX_INFLIGHT = 200
+
+interface FailureDetail {
+  code: string
+  message: string
+  at: string
+  attempt: number
+  statusCode?: number
+  target: {
+    queueName: string
+    deploymentVersion: string
+    url?: string
+  }
+}
+
+interface RegisteredTarget {
+  url: string
+}
+
+export function sanitizeTargetUrl (value: string): string | undefined {
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return url.toString().slice(0, 1024)
+  } catch {
+    return undefined
+  }
+}
+
+function failureDetail (
+  msg: any,
+  attempt: number,
+  code: string,
+  message: string,
+  target?: RegisteredTarget,
+  statusCode?: number
+): FailureDetail {
+  return {
+    code: code.slice(0, 64),
+    message: message.slice(0, 512),
+    at: new Date().toISOString(),
+    attempt,
+    ...(statusCode !== undefined ? { statusCode } : {}),
+    target: {
+      queueName: String(msg.queue_name).slice(0, 256),
+      deploymentVersion: String(msg.deployment_version).slice(0, 256),
+      ...(target?.url ? { url: sanitizeTargetUrl(target.url) } : {}),
+    },
+  }
+}
+
+function queuePayload (msg: any): any {
+  return msg.payload_encoding === 'cbor' ? decode(msg.payload_bytes) : msg.payload
+}
+
+// A valid v5 devalue payload containing a plain diagnostic object. Keeping the
+// user-facing error small avoids persisting transport response bodies or stacks.
+function terminalError (failure: FailureDetail): Buffer {
+  const value = [{ name: 1, message: 2, code: 3 }, 'QueueDeliveryError', failure.message, failure.code]
+  return Buffer.from(`devl${JSON.stringify(value)}`)
+}
+
+function eventError (error: Buffer): Buffer {
+  return Buffer.from(JSON.stringify({ error: error.toString('base64') }))
+}
+
+async function failRun (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
+  const error = terminalError(failure)
+  const failed = await client.query(
+    `UPDATE workflow_runs
+     SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
+     WHERE id = $1 AND application_id = $2 AND status IN ('pending', 'running')
+     RETURNING id`,
+    [msg.run_id, msg.application_id, error]
+  )
+  if (failed.rows.length === 0) return
+
+  await client.query(
+    `UPDATE workflow_hooks SET status = 'disposed', disposed_at = NOW()
+     WHERE run_id = $1 AND application_id = $2 AND status != 'disposed'`,
+    [msg.run_id, msg.application_id]
+  )
+  await client.query(
+    `UPDATE workflow_waits SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+     WHERE run_id = $1 AND application_id = $2 AND status = 'waiting'`,
+    [msg.run_id, msg.application_id]
+  )
+  await client.query(
+    `INSERT INTO workflow_events (run_id, application_id, event_type, event_data)
+     SELECT $1::varchar, $2::integer, 'run_failed', $3
+     WHERE NOT EXISTS (
+       SELECT 1 FROM workflow_events
+       WHERE run_id = $1 AND application_id = $2 AND event_type = 'run_failed'
+     )`,
+    [msg.run_id, msg.application_id, eventError(error)]
+  )
+}
+
+async function ensureRunForWorkflowDelivery (client: pg.PoolClient, msg: any): Promise<void> {
+  if (!msg.run_id) return
+  let payload
+  try {
+    payload = queuePayload(msg)
+  } catch {}
+  const runInput = payload?.runInput
+  const workflowName = typeof runInput?.workflowName === 'string'
+    ? runInput.workflowName
+    : msg.queue_name.slice('__wkf_workflow_'.length)
+  const deploymentId = typeof runInput?.deploymentId === 'string'
+    ? runInput.deploymentId
+    : msg.deployment_version
+
+  await client.query(
+    `INSERT INTO workflow_runs
+       (id, application_id, workflow_name, deployment_id, status, execution_context, spec_version)
+     VALUES ($1, $2, $3, $4, 'pending', $5, $6)
+     ON CONFLICT (id) DO NOTHING`,
+    [msg.run_id, msg.application_id, workflowName || 'unknown', deploymentId || 'unknown',
+      runInput?.executionContext || null, runInput?.specVersion || null]
+  )
+}
+
+async function failBackgroundStep (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<boolean> {
+  let payload
+  try {
+    payload = queuePayload(msg)
+  } catch {
+    return false
+  }
+  if (!payload || typeof payload.stepId !== 'string') return false
+
+  const step = await client.query(
+    `SELECT s.id, s.status, r.workflow_name
+     FROM workflow_steps s
+     JOIN workflow_runs r ON r.id = s.run_id AND r.application_id = s.application_id
+     WHERE s.run_id = $1 AND s.application_id = $2 AND s.correlation_id = $3
+     FOR UPDATE OF s`,
+    [msg.run_id, msg.application_id, payload.stepId]
+  )
+  // A valid background-step payload must never directly fail the whole run.
+  // A missing/terminal step means another path already resolved its state.
+  if (step.rows.length === 0 || ['completed', 'failed', 'cancelled'].includes(step.rows[0].status)) return true
+
+  const error = terminalError(failure)
+  await client.query(
+    `UPDATE workflow_steps
+     SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
+     WHERE id = $1 AND application_id = $2`,
+    [step.rows[0].id, msg.application_id, error]
+  )
+  await client.query(
+    `INSERT INTO workflow_events
+       (run_id, application_id, event_type, correlation_id, event_data)
+     VALUES ($1, $2, 'step_failed', $3, $4)`,
+    [msg.run_id, msg.application_id, payload.stepId, eventError(error)]
+  )
+
+  const continuation = { runId: msg.run_id }
+  const payloadJson = msg.payload_encoding === 'json' ? JSON.stringify(continuation) : null
+  const payloadBytes = msg.payload_encoding === 'cbor' ? Buffer.from(encode(continuation)) : null
+  await client.query(
+    `INSERT INTO workflow_queue_messages
+       (queue_name, run_id, deployment_version, application_id,
+        payload, payload_bytes, payload_encoding, status)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
+    [`__wkf_workflow_${step.rows[0].workflow_name}`, msg.run_id, msg.deployment_version,
+      msg.application_id, payloadJson, payloadBytes, msg.payload_encoding]
+  )
+  await client.query("SELECT pg_notify('deferred_messages', '{}')")
+  return true
+}
+
+async function terminalize (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
+  // v5 dispatches background steps through the workflow queue, while v4 uses
+  // a dedicated step queue. The payload is the authoritative discriminator.
+  if (await failBackgroundStep(client, msg, failure)) return
+  if (msg.queue_name.startsWith('__wkf_workflow_')) {
+    await failRun(client, msg, failure)
+  } else if (msg.queue_name.startsWith('__wkf_step_')) {
+    await failRun(client, msg, failure)
+  }
+}
+
+async function lockRunForTerminalization (client: pg.PoolClient, msg: any): Promise<void> {
+  if (!msg.run_id) return
+  if (msg.queue_name.startsWith('__wkf_workflow_')) await ensureRunForWorkflowDelivery(client, msg)
+  await client.query(
+    'SELECT id FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
+    [msg.run_id, msg.application_id]
+  )
+}
 
 export function createPoller (pool: pg.Pool, connectionString: string, log: any) {
   let stopped = false
@@ -124,21 +318,32 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
   async function executeOnce (): Promise<void> {
     const client = await pool.connect()
     try {
-      // 1. Promote deferred messages that are due
+      // 1. Terminalize rows left at the retry ceiling by older pollers.
+      const exhausted = await client.query(
+        `SELECT * FROM workflow_queue_messages
+         WHERE status = 'failed' AND attempts >= 10
+         ORDER BY created_at ASC
+         LIMIT 100`
+      )
+      for (const msg of exhausted.rows) {
+        await handleExhaustedMessage(client, msg)
+      }
+
+      // 2. Promote deferred messages that are due
       await client.query(
         `UPDATE workflow_queue_messages
-         SET status = 'pending'
+         SET status = 'pending', updated_at = NOW()
          WHERE status = 'deferred' AND deliver_at <= NOW()`
       )
 
-      // 2. Retry failed messages that are due
+      // 3. Retry failed messages that are due
       await client.query(
         `UPDATE workflow_queue_messages
-         SET status = 'pending'
+         SET status = 'pending', updated_at = NOW()
          WHERE status = 'failed' AND next_retry_at <= NOW() AND attempts < 10`
       )
 
-      // 3. Claim pending messages (excluding those already in flight) and
+      // 4. Claim pending messages (excluding those already in flight) and
       // dispatch each in its own task. We do NOT await the dispatches here:
       // a single slow or hung handler must not block the poll loop (the
       // single-flight `executing` guard would otherwise freeze the whole queue
@@ -163,7 +368,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
         }
       }
 
-      // 4. Schedule next wake-up based on earliest deferred/retry message
+      // 5. Schedule next wake-up based on earliest deferred/retry message
       // Fire-and-forget: must not block executeOnce so pendingNotify re-runs
       // are not delayed, and so re-runs use their own pool connection for the query
       scheduleNextWakeup()
@@ -200,7 +405,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
       log.info(`[POLLER] dispatched msgId=${msg.id} queue=${msg.queue_name} encoding=${msg.payload_encoding} status=${result.statusCode} timeoutSeconds=${result.timeoutSeconds} success=${result.success}`)
 
       const client = await pool.connect()
-      try { await handleDispatchResult(client, msg, result) } finally { client.release() }
+      try { await handleDispatchResult(client, msg, result, route) } finally { client.release() }
     } catch (err) {
       // Leave the message 'pending'; removing it from inFlight (below) lets the
       // next poll retry it.
@@ -229,16 +434,24 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
       )
 
       for (const orphan of orphans.rows) {
-        await client.query(
-          `UPDATE workflow_runs SET status = 'failed', error = $2, completed_at = NOW(), updated_at = NOW()
-           WHERE id = $1`,
-          [orphan.id, JSON.stringify({ message: 'Run orphaned: no activity for 15 minutes', code: 'ORPHANED' })]
-        )
-        await client.query(
-          `INSERT INTO workflow_events (run_id, application_id, event_type, event_data)
-           VALUES ($1, $2, 'run_failed', NULL)`,
-          [orphan.id, orphan.application_id]
-        )
+        await client.query('BEGIN')
+        try {
+          await client.query(
+            'SELECT id FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
+            [orphan.id, orphan.application_id]
+          )
+          const msg = {
+            run_id: orphan.id,
+            application_id: orphan.application_id,
+            queue_name: '__wkf_workflow_orphaned',
+            deployment_version: orphan.deployment_id,
+          }
+          await failRun(client, msg, failureDetail(msg, 0, 'ORPHANED', 'Run orphaned: no activity for 15 minutes'))
+          await client.query('COMMIT')
+        } catch (err) {
+          await client.query('ROLLBACK')
+          throw err
+        }
       }
     } catch (err) {
       log.error({ err }, 'Orphan check error')
@@ -279,80 +492,6 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
     }
   }
 
-  async function handleNoRoute (client: pg.PoolClient, msg: any): Promise<void> {
-    if (isMaxAttempts(msg.attempts)) {
-      await client.query(
-        `UPDATE workflow_queue_messages SET status = 'dead', updated_at = NOW()
-         WHERE id = $1`,
-        [msg.id]
-      )
-    } else {
-      const delay = getRetryDelay(msg.attempts)
-      await client.query(
-        `UPDATE workflow_queue_messages
-         SET status = 'failed', attempts = attempts + 1,
-             next_retry_at = NOW() + make_interval(secs => $2)
-         WHERE id = $1`,
-        [msg.id, delay / 1000]
-      )
-    }
-  }
-
-  async function handleDispatchResult (client: pg.PoolClient, msg: any, result: DispatchResult): Promise<void> {
-    if (result.success) {
-      // Re-enqueue preserves the original encoding so the next dispatch
-      // continues using the same Content-Type as the run's specVersion.
-      const payloadJson = msg.payload_encoding === 'json' ? JSON.stringify(msg.payload) : null
-      const payloadBytes = msg.payload_encoding === 'cbor' ? msg.payload_bytes : null
-
-      if (typeof result.timeoutSeconds === 'number' && result.timeoutSeconds > 0) {
-        const delaySecs = result.timeoutSeconds
-        await client.query(
-          `INSERT INTO workflow_queue_messages
-           (queue_name, run_id, deployment_version, application_id,
-            payload, payload_bytes, payload_encoding, status, deliver_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, 'deferred', NOW() + make_interval(secs => $8))`,
-          [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
-            payloadJson, payloadBytes, msg.payload_encoding, delaySecs]
-        )
-        await client.query("SELECT pg_notify('deferred_messages', '{}')")
-      } else if (typeof result.timeoutSeconds === 'number' && result.timeoutSeconds === 0) {
-        await client.query(
-          `INSERT INTO workflow_queue_messages
-           (queue_name, run_id, deployment_version, application_id,
-            payload, payload_bytes, payload_encoding, status)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
-          [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
-            payloadJson, payloadBytes, msg.payload_encoding]
-        )
-        await client.query("SELECT pg_notify('deferred_messages', '{}')")
-      }
-      await client.query(
-        `UPDATE workflow_queue_messages SET status = 'delivered', delivered_at = NOW()
-         WHERE id = $1`,
-        [msg.id]
-      )
-    } else {
-      const attempts = msg.attempts + 1
-      if (isMaxAttempts(attempts)) {
-        await client.query(
-          `UPDATE workflow_queue_messages SET status = 'dead', attempts = $2
-           WHERE id = $1`,
-          [msg.id, attempts]
-        )
-      } else {
-        const delay = getRetryDelay(attempts)
-        await client.query(
-          `UPDATE workflow_queue_messages
-           SET status = 'failed', attempts = $2,
-               next_retry_at = NOW() + make_interval(secs => $3)
-           WHERE id = $1`,
-          [msg.id, attempts, delay / 1000]
-        )
-      }
-    }
-  }
-
   return {
     start () {
       stopped = false
@@ -364,5 +503,147 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
       teardownListener()
       await leader.stop()
     },
+  }
+}
+
+export async function handleExhaustedMessage (client: pg.PoolClient, msg: any): Promise<void> {
+  const failure = msg.last_failure || failureDetail(
+    msg,
+    msg.attempts,
+    'RETRY_EXHAUSTED',
+    'Queue delivery exhausted all retry attempts'
+  )
+
+  await client.query('BEGIN')
+  try {
+    await lockRunForTerminalization(client, msg)
+    const updated = await client.query(
+      `UPDATE workflow_queue_messages
+       SET status = 'dead', last_failure = $4, dead_at = NOW(), terminalized_at = NOW(),
+           next_retry_at = NULL, updated_at = NOW()
+       WHERE id = $1 AND application_id = $2 AND status = 'failed' AND attempts = $3
+       RETURNING id`,
+      [msg.id, msg.application_id, msg.attempts, failure]
+    )
+    if (updated.rows.length > 0) await terminalize(client, msg, failure)
+    await client.query('COMMIT')
+  } catch (err) {
+    await client.query('ROLLBACK')
+    throw err
+  }
+}
+
+export async function handleNoRoute (client: pg.PoolClient, msg: any): Promise<void> {
+  const attempts = msg.attempts + 1
+  const failure = failureDetail(
+    msg,
+    attempts,
+    'ROUTE_NOT_FOUND',
+    'No registered target is available for this queue delivery'
+  )
+
+  await client.query('BEGIN')
+  try {
+    if (isMaxAttempts(attempts)) {
+      await lockRunForTerminalization(client, msg)
+      const updated = await client.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'dead', attempts = $4, last_failure = $5, dead_at = NOW(),
+             terminalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
+         WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
+         RETURNING id`,
+        [msg.id, msg.application_id, msg.attempts, attempts, failure]
+      )
+      if (updated.rows.length > 0) await terminalize(client, msg, failure)
+    } else {
+      const delay = getRetryDelay(attempts)
+      await client.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'failed', attempts = $4, last_failure = $5,
+             next_retry_at = NOW() + make_interval(secs => $6), updated_at = NOW()
+         WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3`,
+        [msg.id, msg.application_id, msg.attempts, attempts, failure, delay / 1000]
+      )
+    }
+    await client.query('COMMIT')
+  } catch (err) {
+    await client.query('ROLLBACK')
+    throw err
+  }
+}
+
+export async function handleDispatchResult (
+  client: pg.PoolClient,
+  msg: any,
+  result: DispatchResult,
+  target?: RegisteredTarget
+): Promise<void> {
+  await client.query('BEGIN')
+  try {
+    if (result.success) {
+      const delivered = await client.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'delivered', delivered_at = NOW(), updated_at = NOW()
+         WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
+         RETURNING id`,
+        [msg.id, msg.application_id, msg.attempts]
+      )
+
+      if (delivered.rows.length > 0 && typeof result.timeoutSeconds === 'number') {
+        const payloadJson = msg.payload_encoding === 'json' ? JSON.stringify(msg.payload) : null
+        const payloadBytes = msg.payload_encoding === 'cbor' ? msg.payload_bytes : null
+        if (result.timeoutSeconds > 0) {
+          await client.query(
+            `INSERT INTO workflow_queue_messages
+               (queue_name, run_id, deployment_version, application_id,
+                payload, payload_bytes, payload_encoding, status, deliver_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, 'deferred', NOW() + make_interval(secs => $8))`,
+            [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
+              payloadJson, payloadBytes, msg.payload_encoding, result.timeoutSeconds]
+          )
+          await client.query("SELECT pg_notify('deferred_messages', '{}')")
+        } else if (result.timeoutSeconds === 0) {
+          await client.query(
+            `INSERT INTO workflow_queue_messages
+               (queue_name, run_id, deployment_version, application_id,
+                payload, payload_bytes, payload_encoding, status)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
+            [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
+              payloadJson, payloadBytes, msg.payload_encoding]
+          )
+          await client.query("SELECT pg_notify('deferred_messages', '{}')")
+        }
+      }
+    } else {
+      const attempts = msg.attempts + 1
+      const error = result.error || { code: 'DISPATCH_ERROR', message: 'Target request failed' }
+      const failure = failureDetail(msg, attempts, error.code, error.message, target, result.statusCode)
+
+      if (isMaxAttempts(attempts)) {
+        await lockRunForTerminalization(client, msg)
+        const updated = await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'dead', attempts = $4, last_failure = $5, dead_at = NOW(),
+               terminalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
+           WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
+           RETURNING id`,
+          [msg.id, msg.application_id, msg.attempts, attempts, failure]
+        )
+        if (updated.rows.length > 0) await terminalize(client, msg, failure)
+      } else {
+        const delay = getRetryDelay(attempts)
+        await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'failed', attempts = $4, last_failure = $5,
+               next_retry_at = NOW() + make_interval(secs => $6), updated_at = NOW()
+           WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3`,
+          [msg.id, msg.application_id, msg.attempts, attempts, failure, delay / 1000]
+        )
+      }
+    }
+    await client.query('COMMIT')
+  } catch (err) {
+    await client.query('ROLLBACK')
+    throw err
   }
 }

--- a/packages/workflow/queue/router.ts
+++ b/packages/workflow/queue/router.ts
@@ -2,7 +2,6 @@ import type pg from 'pg'
 
 export interface RouteResult {
   url: string
-  podId: string
 }
 
 export async function routeMessage (
@@ -22,28 +21,21 @@ export async function routeMessage (
     return null // Version expired
   }
 
-  // Find registered handlers for this version
-  const handlers = await pool.query(
-    `SELECT pod_id, workflow_url, step_url, webhook_url FROM workflow_queue_handlers
+  // Find registered destinations for this version.
+  const registrations = await pool.query(
+    `SELECT workflow_url, step_url, webhook_url FROM workflow_queue_handlers
      WHERE application_id = $1 AND deployment_version = $2
      ORDER BY last_heartbeat DESC`,
     [appId, deploymentVersion]
   )
 
-  if (handlers.rows.length === 0) return null
+  if (registrations.rows.length === 0) return null
 
-  // Round-robin: pick based on a simple random selection
-  const handler = handlers.rows[Math.floor(Math.random() * handlers.rows.length)]
+  const urlField = queueName.startsWith('__wkf_step_')
+    ? 'step_url'
+    : queueName.startsWith('__wkf_workflow_') ? 'workflow_url' : 'webhook_url'
+  const urls = [...new Set(registrations.rows.map(registration => registration[urlField]))]
+  const url = urls[Math.floor(Math.random() * urls.length)]
 
-  // Determine target URL based on queue name
-  let url: string
-  if (queueName.startsWith('__wkf_step_')) {
-    url = handler.step_url
-  } else if (queueName.startsWith('__wkf_workflow_')) {
-    url = handler.workflow_url
-  } else {
-    url = handler.webhook_url
-  }
-
-  return { url, podId: handler.pod_id }
+  return { url }
 }

--- a/packages/workflow/test/dead-letters.test.ts
+++ b/packages/workflow/test/dead-letters.test.ts
@@ -13,7 +13,7 @@ describe('dead-letters', () => {
     await teardownTest(ctx)
   })
 
-  async function createDeadMessage (queueName: string, payload: any): Promise<number> {
+  async function createDeadMessage (queueName: string, payload: any, terminalized = false): Promise<number> {
     const appResult = await ctx.app.pg.query(
       'SELECT id FROM workflow_applications WHERE app_id = $1',
       [ctx.appId]
@@ -22,10 +22,15 @@ describe('dead-letters', () => {
 
     const result = await ctx.app.pg.query(
       `INSERT INTO workflow_queue_messages
-       (queue_name, run_id, deployment_version, application_id, payload, status, attempts)
-       VALUES ($1, 'run-1', 'v1', $2, $3, 'dead', 10)
+       (queue_name, run_id, deployment_version, application_id, payload, status, attempts,
+        last_failure, dead_at, terminalized_at)
+       VALUES ($1, 'run-1', 'v1', $2, $3, 'dead', 10, $4, NOW(),
+               CASE WHEN $5 THEN NOW() ELSE NULL END)
        RETURNING id`,
-      [queueName, applicationId, JSON.stringify(payload)]
+      [queueName, applicationId, JSON.stringify(payload), {
+        code: 'HTTP_503',
+        message: 'Target returned HTTP 503',
+      }, terminalized]
     )
     return result.rows[0].id
   }
@@ -45,6 +50,9 @@ describe('dead-letters', () => {
     assert.ok(Array.isArray(body.data))
     assert.ok(body.data.length >= 2)
     assert.equal(body.data[0].queueName, 'queue-b') // newest first
+    assert.equal(body.data[0].lastFailure.code, 'HTTP_503')
+    assert.ok(body.data[0].deadAt)
+    assert.equal(body.data[0].terminalizedAt, null)
   })
 
   it('should filter by queueName', async () => {
@@ -109,6 +117,23 @@ describe('dead-letters', () => {
     })
 
     assert.equal(response.statusCode, 400)
+  })
+
+  it('should reject retry for a terminalized dead message', async () => {
+    const id = await createDeadMessage('terminalized-queue', { retry: false }, true)
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/dead-letters/msg_${id}/retry`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+    })
+
+    assert.equal(response.statusCode, 400)
+    const check = await ctx.app.pg.query(
+      'SELECT status, terminalized_at FROM workflow_queue_messages WHERE id = $1',
+      [id]
+    )
+    assert.equal(check.rows[0].status, 'dead')
+    assert.ok(check.rows[0].terminalized_at)
   })
 
   it('should paginate dead letters', async () => {

--- a/packages/workflow/test/dead-letters.test.ts
+++ b/packages/workflow/test/dead-letters.test.ts
@@ -13,7 +13,7 @@ describe('dead-letters', () => {
     await teardownTest(ctx)
   })
 
-  async function createDeadMessage (queueName: string, payload: any, terminalized = false): Promise<number> {
+  async function createDeadMessage (queueName: string, payload: any, failureFinalized = false): Promise<number> {
     const appResult = await ctx.app.pg.query(
       'SELECT id FROM workflow_applications WHERE app_id = $1',
       [ctx.appId]
@@ -23,14 +23,14 @@ describe('dead-letters', () => {
     const result = await ctx.app.pg.query(
       `INSERT INTO workflow_queue_messages
        (queue_name, run_id, deployment_version, application_id, payload, status, attempts,
-        last_failure, dead_at, terminalized_at)
+        last_failure, dead_at, failure_finalized_at)
        VALUES ($1, 'run-1', 'v1', $2, $3, 'dead', 10, $4, NOW(),
                CASE WHEN $5 THEN NOW() ELSE NULL END)
        RETURNING id`,
       [queueName, applicationId, JSON.stringify(payload), {
         code: 'HTTP_503',
         message: 'Target returned HTTP 503',
-      }, terminalized]
+      }, failureFinalized]
     )
     return result.rows[0].id
   }
@@ -52,7 +52,7 @@ describe('dead-letters', () => {
     assert.equal(body.data[0].queueName, 'queue-b') // newest first
     assert.equal(body.data[0].lastFailure.code, 'HTTP_503')
     assert.ok(body.data[0].deadAt)
-    assert.equal(body.data[0].terminalizedAt, null)
+    assert.equal(body.data[0].failureFinalizedAt, null)
   })
 
   it('should filter by queueName', async () => {
@@ -119,8 +119,8 @@ describe('dead-letters', () => {
     assert.equal(response.statusCode, 400)
   })
 
-  it('should reject retry for a terminalized dead message', async () => {
-    const id = await createDeadMessage('terminalized-queue', { retry: false }, true)
+  it('should reject retry for a dead message with a finalized failure', async () => {
+    const id = await createDeadMessage('finalized-failure-queue', { retry: false }, true)
     const response = await ctx.app.inject({
       method: 'POST',
       url: `/api/v1/apps/${ctx.appId}/dead-letters/msg_${id}/retry`,
@@ -129,11 +129,11 @@ describe('dead-letters', () => {
 
     assert.equal(response.statusCode, 400)
     const check = await ctx.app.pg.query(
-      'SELECT status, terminalized_at FROM workflow_queue_messages WHERE id = $1',
+      'SELECT status, failure_finalized_at FROM workflow_queue_messages WHERE id = $1',
       [id]
     )
     assert.equal(check.rows[0].status, 'dead')
-    assert.ok(check.rows[0].terminalized_at)
+    assert.ok(check.rows[0].failure_finalized_at)
   })
 
   it('should paginate dead letters', async () => {

--- a/packages/workflow/test/dispatcher.test.ts
+++ b/packages/workflow/test/dispatcher.test.ts
@@ -103,4 +103,33 @@ describe('dispatcher', () => {
       await new Promise<void>((resolve) => timeoutServer.close(() => resolve()))
     }
   })
+
+  it('returns a bounded normalized HTTP error without the response body', async () => {
+    const errorServer = createServer((_req, res) => {
+      res.writeHead(503, { 'content-type': 'text/plain' })
+      res.end(`secret-${'x'.repeat(1000)}`)
+    })
+    await new Promise<void>((resolve) => errorServer.listen(0, resolve))
+    const p = (errorServer.address() as AddressInfo).port
+
+    try {
+      const result = await dispatchMessage({
+        url: `http://localhost:${p}/flow`,
+        queueName: '__wkf_workflow_test',
+        messageId: 4,
+        payload: { runId: 'r4' },
+        payloadBytes: null,
+        payloadEncoding: 'json',
+        attempt: 9,
+      })
+      assert.equal(result.success, false)
+      assert.equal(result.statusCode, 503)
+      assert.deepEqual(result.error, {
+        code: 'HTTP_503',
+        message: 'Target returned HTTP 503',
+      })
+    } finally {
+      await new Promise<void>((resolve) => errorServer.close(() => resolve()))
+    }
+  })
 })

--- a/packages/workflow/test/events.test.ts
+++ b/packages/workflow/test/events.test.ts
@@ -277,4 +277,143 @@ describe('events', () => {
     const completed = JSON.parse(completeRes.body)
     assert.equal(completed.wait.status, 'completed')
   })
+
+  it('paginates run events in both directions without dropping the cursor', async () => {
+    const createRes = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        eventType: 'run_created',
+        specVersion: 2,
+        eventData: { deploymentId: 'v1.0.0', workflowName: 'pagination-test', input: {} },
+      },
+    })
+    const runId = JSON.parse(createRes.body).run.runId
+    const run = await ctx.app.pg.query('SELECT application_id FROM workflow_runs WHERE id = $1', [runId])
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_events (run_id, application_id, event_type)
+       SELECT $1, $2, 'pagination_event' FROM generate_series(1, 4)
+       RETURNING id`,
+      [runId, run.rows[0].application_id]
+    )
+    const allEvents = await ctx.app.pg.query('SELECT id FROM workflow_events WHERE run_id = $1 ORDER BY id ASC', [runId])
+    const ids = allEvents.rows.map(row => String(row.id))
+    const baseUrl = `/api/v1/apps/${ctx.appId}/runs/${runId}/events`
+    const headers = { authorization: `Bearer ${ctx.apiKey}` }
+
+    const first = JSON.parse((await ctx.app.inject({ method: 'GET', url: `${baseUrl}?limit=3`, headers })).body)
+    assert.deepEqual(first.data.map((event: any) => event.eventId), ids.slice(0, 3))
+    assert.equal(first.cursor, ids[2])
+    assert.equal(first.hasMore, true)
+
+    const final = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}?limit=3&cursor=${first.cursor}`,
+      headers,
+    })).body)
+    assert.deepEqual(final.data.map((event: any) => event.eventId), ids.slice(3))
+    assert.equal(final.cursor, ids.at(-1))
+    assert.equal(final.hasMore, false)
+
+    const empty = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}?cursor=${final.cursor}`,
+      headers,
+    })).body)
+    assert.deepEqual(empty.data, [])
+    assert.equal(empty.cursor, final.cursor)
+
+    const later = await ctx.app.pg.query(
+      `INSERT INTO workflow_events (run_id, application_id, event_type)
+       VALUES ($1, $2, 'later_event') RETURNING id`,
+      [runId, run.rows[0].application_id]
+    )
+    const incremental = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}?cursor=${final.cursor}`,
+      headers,
+    })).body)
+    assert.deepEqual(incremental.data.map((event: any) => event.eventId), [String(later.rows[0].id)])
+    assert.equal(incremental.cursor, String(later.rows[0].id))
+
+    const desc = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}?limit=2&sortOrder=desc`,
+      headers,
+    })).body)
+    assert.deepEqual(desc.data.map((event: any) => event.eventId), [String(later.rows[0].id), ids.at(-1)])
+    assert.equal(desc.cursor, ids.at(-1))
+
+    const descNext = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}?limit=2&sortOrder=desc&cursor=${desc.cursor}`,
+      headers,
+    })).body)
+    assert.deepEqual(descNext.data.map((event: any) => event.eventId), ids.slice(-3, -1).reverse())
+  })
+
+  it('paginates correlation events in both directions and preserves empty-page cursors', async () => {
+    const createRes = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        eventType: 'run_created',
+        specVersion: 2,
+        eventData: { deploymentId: 'v1.0.0', workflowName: 'correlation-pagination-test', input: {} },
+      },
+    })
+    const runId = JSON.parse(createRes.body).run.runId
+    const run = await ctx.app.pg.query('SELECT application_id FROM workflow_runs WHERE id = $1', [runId])
+    const correlationId = `pagination-${randomBytes(8).toString('hex')}`
+    const inserted = await ctx.app.pg.query(
+      `INSERT INTO workflow_events (run_id, application_id, event_type, correlation_id)
+       SELECT $1, $2, 'correlation_event', $3 FROM generate_series(1, 4)
+       RETURNING id`,
+      [runId, run.rows[0].application_id, correlationId]
+    )
+    const ids = inserted.rows.map(row => String(row.id))
+    const baseUrl = `/api/v1/apps/${ctx.appId}/events/by-correlation?correlationId=${correlationId}`
+    const headers = { authorization: `Bearer ${ctx.apiKey}` }
+
+    const first = JSON.parse((await ctx.app.inject({ method: 'GET', url: `${baseUrl}&limit=2`, headers })).body)
+    assert.deepEqual(first.data.map((event: any) => event.eventId), ids.slice(0, 2))
+    assert.equal(first.cursor, ids[1])
+    assert.equal(first.hasMore, true)
+
+    const final = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}&limit=2&cursor=${first.cursor}`,
+      headers,
+    })).body)
+    assert.deepEqual(final.data.map((event: any) => event.eventId), ids.slice(2))
+    assert.equal(final.cursor, ids.at(-1))
+    assert.equal(final.hasMore, false)
+
+    const empty = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}&cursor=${final.cursor}`,
+      headers,
+    })).body)
+    assert.deepEqual(empty.data, [])
+    assert.equal(empty.cursor, final.cursor)
+
+    const desc = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}&limit=2&sortOrder=desc`,
+      headers,
+    })).body)
+    assert.deepEqual(desc.data.map((event: any) => event.eventId), ids.slice(-2).reverse())
+    assert.equal(desc.cursor, ids.at(-2))
+
+    const descFinal = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `${baseUrl}&limit=2&sortOrder=desc&cursor=${desc.cursor}`,
+      headers,
+    })).body)
+    assert.deepEqual(descFinal.data.map((event: any) => event.eventId), ids.slice(0, 2).reverse())
+    assert.equal(descFinal.cursor, ids[0])
+    assert.equal(descFinal.hasMore, false)
+  })
 })

--- a/packages/workflow/test/poller.test.ts
+++ b/packages/workflow/test/poller.test.ts
@@ -1,0 +1,225 @@
+import { randomUUID } from 'node:crypto'
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { decode, encode } from 'cbor-x'
+import { handleDispatchResult, handleNoRoute } from '../queue/poller.ts'
+import { setupTest, teardownTest, type TestContext } from './helper.ts'
+
+describe('poller result handling', () => {
+  let ctx: TestContext
+  let applicationId: number
+
+  before(async () => {
+    ctx = await setupTest()
+    const app = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1',
+      [ctx.appId]
+    )
+    applicationId = app.rows[0].id
+  })
+
+  after(async () => {
+    await teardownTest(ctx)
+  })
+
+  async function createRun (workflowName: string): Promise<string> {
+    const runId = `run-${randomUUID()}`
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_runs
+         (id, application_id, workflow_name, deployment_id, status, started_at)
+       VALUES ($1, $2, $3, 'v1', 'running', NOW())`,
+      [runId, applicationId, workflowName]
+    )
+    return runId
+  }
+
+  it('terminalizes a workflow delivery exactly once and sanitizes target metadata', async () => {
+    const runId = await createRun('terminal-workflow')
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_hooks
+         (id, run_id, application_id, correlation_id, token)
+       VALUES ($1, $2, $3, 'hook-1', $4)`,
+      [randomUUID(), runId, applicationId, randomUUID()]
+    )
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_waits (id, run_id, application_id, correlation_id)
+       VALUES ($1, $2, $3, 'wait-1')`,
+      [randomUUID(), runId, applicationId]
+    )
+    const inserted = await ctx.app.pg.query(
+      `INSERT INTO workflow_queue_messages
+         (queue_name, run_id, deployment_version, application_id, payload, status, attempts)
+       VALUES ('__wkf_workflow_terminal-workflow', $1, 'v1', $2, $3, 'pending', 9)
+       RETURNING *`,
+      [runId, applicationId, JSON.stringify({ runId })]
+    )
+    const msg = inserted.rows[0]
+    const client = await ctx.app.pg.connect()
+    try {
+      const failure = {
+        success: false,
+        statusCode: 503,
+        error: { code: 'HTTP_503', message: 'Target returned HTTP 503' },
+      }
+      const target = {
+        url: 'https://user:password@example.com/flow?token=secret#fragment',
+      }
+      await handleDispatchResult(client, msg, failure, target)
+      await handleDispatchResult(client, msg, failure, target)
+    } finally {
+      client.release()
+    }
+
+    const message = (await ctx.app.pg.query(
+      `SELECT status, attempts, last_failure, dead_at, terminalized_at
+       FROM workflow_queue_messages WHERE id = $1`,
+      [msg.id]
+    )).rows[0]
+    assert.equal(message.status, 'dead')
+    assert.equal(message.attempts, 10)
+    assert.equal(message.last_failure.target.url, 'https://example.com/flow')
+    assert.ok(message.dead_at)
+    assert.ok(message.terminalized_at)
+
+    const run = (await ctx.app.pg.query(
+      'SELECT status FROM workflow_runs WHERE id = $1',
+      [runId]
+    )).rows[0]
+    assert.equal(run.status, 'failed')
+    const events = await ctx.app.pg.query(
+      `SELECT id FROM workflow_events
+       WHERE run_id = $1 AND event_type = 'run_failed'`,
+      [runId]
+    )
+    assert.equal(events.rows.length, 1)
+    assert.equal((await ctx.app.pg.query(
+      'SELECT status FROM workflow_hooks WHERE run_id = $1',
+      [runId]
+    )).rows[0].status, 'disposed')
+    assert.equal((await ctx.app.pg.query(
+      'SELECT status FROM workflow_waits WHERE run_id = $1',
+      [runId]
+    )).rows[0].status, 'completed')
+  })
+
+  for (const encoding of ['json', 'cbor'] as const) {
+    for (const queueKind of ['step', 'workflow'] as const) {
+      it(`terminalizes a ${encoding.toUpperCase()} ${queueKind}-queue background step with one continuation`, async () => {
+        const workflowName = `background-${encoding}`
+        const runId = await createRun(workflowName)
+        const stepId = `step-${randomUUID()}`
+        await ctx.app.pg.query(
+          `INSERT INTO workflow_steps
+             (id, run_id, application_id, correlation_id, step_name, status, started_at)
+           VALUES ($1, $2, $3, $4, 'background-step', 'running', NOW())`,
+          [randomUUID(), runId, applicationId, stepId]
+        )
+        const payload = { workflowName, workflowRunId: runId, workflowStartedAt: Date.now(), stepId }
+        const inserted = await ctx.app.pg.query(
+          `INSERT INTO workflow_queue_messages
+             (queue_name, run_id, deployment_version, application_id,
+              payload, payload_bytes, payload_encoding, status, attempts)
+           VALUES ($1, $2, 'v1', $3, $4, $5, $6, 'pending', 9)
+           RETURNING *`,
+          [queueKind === 'step' ? `__wkf_step_${stepId}` : `__wkf_workflow_${workflowName}`, runId, applicationId,
+            encoding === 'json' ? JSON.stringify(payload) : null,
+            encoding === 'cbor' ? Buffer.from(encode(payload)) : null,
+            encoding]
+        )
+        const client = await ctx.app.pg.connect()
+        try {
+          await handleDispatchResult(client, inserted.rows[0], {
+            success: false,
+            statusCode: 0,
+            error: { code: 'ECONNRESET', message: 'Target connection was reset' },
+          })
+        } finally {
+          client.release()
+        }
+
+        const step = (await ctx.app.pg.query(
+          'SELECT status FROM workflow_steps WHERE run_id = $1 AND correlation_id = $2',
+          [runId, stepId]
+        )).rows[0]
+        assert.equal(step.status, 'failed')
+        assert.equal((await ctx.app.pg.query(
+          'SELECT status FROM workflow_runs WHERE id = $1',
+          [runId]
+        )).rows[0].status, 'running')
+        assert.equal((await ctx.app.pg.query(
+          `SELECT id FROM workflow_events
+           WHERE run_id = $1 AND event_type = 'step_failed' AND correlation_id = $2`,
+          [runId, stepId]
+        )).rows.length, 1)
+
+        const continuations = await ctx.app.pg.query(
+          `SELECT payload, payload_bytes, payload_encoding
+           FROM workflow_queue_messages
+           WHERE run_id = $1 AND queue_name = $2 AND status = 'pending'`,
+          [runId, `__wkf_workflow_${workflowName}`]
+        )
+        assert.equal(continuations.rows.length, 1)
+        const continuation = encoding === 'json'
+          ? continuations.rows[0].payload
+          : decode(continuations.rows[0].payload_bytes)
+        assert.equal(continuation.runId, runId)
+        assert.equal(continuations.rows[0].payload_encoding, encoding)
+      })
+    }
+  }
+
+  it('counts a no-route attempt before deciding it is terminal', async () => {
+    const inserted = await ctx.app.pg.query(
+      `INSERT INTO workflow_queue_messages
+         (queue_name, run_id, deployment_version, application_id, payload, status, attempts)
+       VALUES ('webhook', '', 'v1', $1, '{}', 'pending', 9)
+       RETURNING *`,
+      [applicationId]
+    )
+    const client = await ctx.app.pg.connect()
+    try {
+      await handleNoRoute(client, inserted.rows[0])
+    } finally {
+      client.release()
+    }
+    const row = (await ctx.app.pg.query(
+      'SELECT status, attempts, last_failure, updated_at FROM workflow_queue_messages WHERE id = $1',
+      [inserted.rows[0].id]
+    )).rows[0]
+    assert.equal(row.status, 'dead')
+    assert.equal(row.attempts, 10)
+    assert.equal(row.last_failure.code, 'ROUTE_NOT_FOUND')
+    assert.ok(row.updated_at)
+  })
+
+  it('re-enqueues a successful continuation only when delivery wins the predicate', async () => {
+    const runId = await createRun('successful-continuation')
+    const inserted = await ctx.app.pg.query(
+      `INSERT INTO workflow_queue_messages
+         (queue_name, run_id, deployment_version, application_id, payload, status)
+       VALUES ('__wkf_workflow_successful-continuation', $1, 'v1', $2, $3, 'pending')
+       RETURNING *`,
+      [runId, applicationId, JSON.stringify({ runId })]
+    )
+    const client = await ctx.app.pg.connect()
+    try {
+      const result = { success: true, statusCode: 200, timeoutSeconds: 0 }
+      await handleDispatchResult(client, inserted.rows[0], result)
+      await handleDispatchResult(client, inserted.rows[0], result)
+    } finally {
+      client.release()
+    }
+
+    assert.equal((await ctx.app.pg.query(
+      'SELECT status FROM workflow_queue_messages WHERE id = $1',
+      [inserted.rows[0].id]
+    )).rows[0].status, 'delivered')
+    const continuations = await ctx.app.pg.query(
+      `SELECT id FROM workflow_queue_messages
+       WHERE run_id = $1 AND queue_name = '__wkf_workflow_successful-continuation'
+         AND status = 'pending'`,
+      [runId]
+    )
+    assert.equal(continuations.rows.length, 1)
+  })
+})

--- a/packages/workflow/test/poller.test.ts
+++ b/packages/workflow/test/poller.test.ts
@@ -33,7 +33,7 @@ describe('poller result handling', () => {
     return runId
   }
 
-  it('terminalizes a workflow delivery exactly once and sanitizes target metadata', async () => {
+  it('finalizes a workflow delivery failure exactly once and sanitizes target metadata', async () => {
     const runId = await createRun('terminal-workflow')
     await ctx.app.pg.query(
       `INSERT INTO workflow_hooks
@@ -71,7 +71,7 @@ describe('poller result handling', () => {
     }
 
     const message = (await ctx.app.pg.query(
-      `SELECT status, attempts, last_failure, dead_at, terminalized_at
+      `SELECT status, attempts, last_failure, dead_at, failure_finalized_at
        FROM workflow_queue_messages WHERE id = $1`,
       [msg.id]
     )).rows[0]
@@ -79,7 +79,7 @@ describe('poller result handling', () => {
     assert.equal(message.attempts, 10)
     assert.equal(message.last_failure.target.url, 'https://example.com/flow')
     assert.ok(message.dead_at)
-    assert.ok(message.terminalized_at)
+    assert.ok(message.failure_finalized_at)
 
     const run = (await ctx.app.pg.query(
       'SELECT status FROM workflow_runs WHERE id = $1',
@@ -104,7 +104,7 @@ describe('poller result handling', () => {
 
   for (const encoding of ['json', 'cbor'] as const) {
     for (const queueKind of ['step', 'workflow'] as const) {
-      it(`terminalizes a ${encoding.toUpperCase()} ${queueKind}-queue background step with one continuation`, async () => {
+      it(`finalizes a ${encoding.toUpperCase()} ${queueKind}-queue background step failure with one continuation`, async () => {
         const workflowName = `background-${encoding}`
         const runId = await createRun(workflowName)
         const stepId = `step-${randomUUID()}`

--- a/packages/workflow/test/router.test.ts
+++ b/packages/workflow/test/router.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { routeMessage } from '../queue/router.ts'
+import type pg from 'pg'
+
+describe('queue router', () => {
+  it('deduplicates the selected endpoint URLs before random selection', async () => {
+    const pool = {
+      query: async (sql: string) => {
+        if (sql.includes('workflow_deployment_versions')) return { rows: [] }
+        return {
+          rows: [
+            {
+              workflow_url: 'http://service-a/flow',
+              step_url: 'http://service-a/step',
+              webhook_url: 'http://service-a/webhook',
+            },
+            {
+              workflow_url: 'http://service-a/flow',
+              step_url: 'http://service-a/step',
+              webhook_url: 'http://service-a/webhook',
+            },
+            {
+              workflow_url: 'http://service-a/flow',
+              step_url: 'http://service-a/step',
+              webhook_url: 'http://service-a/webhook',
+            },
+            {
+              workflow_url: 'http://service-b/flow',
+              step_url: 'http://service-b/step',
+              webhook_url: 'http://service-b/webhook',
+            },
+          ],
+        }
+      },
+    } as unknown as pg.Pool
+    const random = Math.random
+    Math.random = () => 0.75
+
+    try {
+      const route = await routeMessage(pool, 1, 'v1', '__wkf_workflow_test')
+      assert.deepEqual(route, { url: 'http://service-b/flow' })
+    } finally {
+      Math.random = random
+    }
+  })
+
+  it('selects the endpoint matching the queue type', async () => {
+    const pool = {
+      query: async (sql: string) => {
+        if (sql.includes('workflow_deployment_versions')) return { rows: [] }
+        return {
+          rows: [{
+            workflow_url: 'http://service/flow',
+            step_url: 'http://service/step',
+            webhook_url: 'http://service/webhook',
+          }],
+        }
+      },
+    } as unknown as pg.Pool
+
+    assert.deepEqual(await routeMessage(pool, 1, 'v1', '__wkf_step_test'), { url: 'http://service/step' })
+    assert.deepEqual(await routeMessage(pool, 1, 'v1', '__wkf_workflow_test'), { url: 'http://service/flow' })
+    assert.deepEqual(await routeMessage(pool, 1, 'v1', 'webhook'), { url: 'http://service/webhook' })
+  })
+})

--- a/packages/workflow/test/streams.test.ts
+++ b/packages/workflow/test/streams.test.ts
@@ -107,6 +107,156 @@ describe('streams', () => {
     assert.equal(closeRes.statusCode, 204)
   })
 
+  it('should allocate unique contiguous indexes for concurrent writes', async () => {
+    const streamName = `stream-concurrent-${Date.now()}`
+    const expectedData: string[] = []
+    const writes = Array.from({ length: 10 }, (_, index) => {
+      const single = `single-${index}`
+      const multi = [`multi-${index}-a`, `multi-${index}-b`]
+      expectedData.push(single, ...multi)
+      return [
+        ctx.app.inject({
+          method: 'PUT',
+          url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}`,
+          headers: { authorization: `Bearer ${ctx.apiKey}`, 'content-type': 'application/json' },
+          payload: JSON.stringify(single),
+        }),
+        ctx.app.inject({
+          method: 'PUT',
+          url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}`,
+          headers: {
+            authorization: `Bearer ${ctx.apiKey}`,
+            'content-type': 'application/json',
+            'x-stream-multi': 'true',
+          },
+          payload: JSON.stringify(multi),
+        }),
+      ]
+    }).flat()
+
+    const responses = await Promise.all(writes)
+    assert.ok(responses.every(response => response.statusCode === 204))
+
+    const chunksRes = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}/chunks?limit=1000`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+    })
+    const page = JSON.parse(chunksRes.body) as { data: { index: number; data: string }[] }
+    const actualData = page.data.map(chunk => Buffer.from(chunk.data, 'base64').toString())
+
+    assert.deepEqual(page.data.map(chunk => chunk.index), Array.from({ length: 30 }, (_, index) => index))
+    assert.deepEqual(actualData.toSorted(), expectedData.toSorted())
+    for (let index = 0; index < 10; index++) {
+      const first = actualData.indexOf(`multi-${index}-a`)
+      assert.equal(actualData[first + 1], `multi-${index}-b`)
+    }
+  })
+
+  it('should make close idempotent and reject later writes', async () => {
+    const streamName = `stream-idempotent-close-${Date.now()}`
+    const close = () => ctx.app.inject({
+      method: 'PUT',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}`,
+      headers: {
+        authorization: `Bearer ${ctx.apiKey}`,
+        'content-type': 'application/json',
+        'x-stream-done': 'true',
+      },
+      payload: JSON.stringify({}),
+    })
+
+    assert.equal((await close()).statusCode, 204)
+    assert.equal((await close()).statusCode, 204)
+
+    const writeRes = await ctx.app.inject({
+      method: 'PUT',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}`,
+      headers: { authorization: `Bearer ${ctx.apiKey}`, 'content-type': 'application/json' },
+      payload: JSON.stringify('too late'),
+    })
+    assert.equal(writeRes.statusCode, 400)
+
+    const appResult = await ctx.app.pg.query('SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId])
+    const closeResult = await ctx.app.pg.query(
+      `SELECT COUNT(*)::int AS count FROM workflow_stream_chunks
+       WHERE application_id = $1 AND run_id = $2 AND stream_name = $3 AND is_closed = TRUE`,
+      [appResult.rows[0].id, runId, streamName]
+    )
+    assert.equal(closeResult.rows[0].count, 1)
+  })
+
+  it('should coalesce live flushes while the current flush is pending', async () => {
+    const streamName = `stream-live-single-flight-${Date.now()}`
+    await ctx.app.inject({
+      method: 'PUT',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}`,
+      headers: { authorization: `Bearer ${ctx.apiKey}`, 'content-type': 'application/json' },
+      payload: JSON.stringify('first'),
+    })
+
+    const pool = ctx.app.pg as any
+    const query = pool.query
+    const initialFlush = Promise.withResolvers<void>()
+    const releaseFlush = Promise.withResolvers<void>()
+    let flushes = 0
+    let activeFlushes = 0
+    let maxActiveFlushes = 0
+
+    pool.query = async (...args: any[]) => {
+      const isFlush = typeof args[0] === 'string' && args[0].includes('WITH stream_state AS') && args[1]?.[0] === streamName
+      if (!isFlush) return query.call(pool, ...args)
+
+      activeFlushes++
+      maxActiveFlushes = Math.max(maxActiveFlushes, activeFlushes)
+      try {
+        const result = await query.call(pool, ...args)
+        if (++flushes === 1) {
+          initialFlush.resolve()
+          await releaseFlush.promise
+        }
+        return result
+      } finally {
+        activeFlushes--
+      }
+    }
+
+    try {
+      const readPromise = ctx.app.inject({
+        method: 'GET',
+        url: `/api/v1/apps/${ctx.appId}/streams/${streamName}?stream=true`,
+        headers: { authorization: `Bearer ${ctx.apiKey}` },
+      })
+      await initialFlush.promise
+
+      await ctx.app.inject({
+        method: 'PUT',
+        url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}`,
+        headers: { authorization: `Bearer ${ctx.apiKey}`, 'content-type': 'application/json' },
+        payload: JSON.stringify('second'),
+      })
+      await ctx.app.inject({
+        method: 'PUT',
+        url: `/api/v1/apps/${ctx.appId}/runs/${runId}/streams/${streamName}`,
+        headers: {
+          authorization: `Bearer ${ctx.apiKey}`,
+          'content-type': 'application/json',
+          'x-stream-done': 'true',
+        },
+        payload: JSON.stringify({}),
+      })
+
+      releaseFlush.resolve()
+      const readRes = await readPromise
+      assert.equal(readRes.body, 'firstsecond')
+      assert.equal(maxActiveFlushes, 1)
+      assert.equal(flushes, 2)
+    } finally {
+      releaseFlush.resolve()
+      pool.query = query
+    }
+  })
+
   it('should read with startIndex', async () => {
     const streamName = `stream-offset-${Date.now()}`
 


### PR DESCRIPTION
## Summary

- Finalize workflow and background-step failures when queue delivery retries are exhausted.
- Persist bounded transport failure diagnostics and prevent retries after delivery failures are finalized.
- Fix ascending and descending event pagination cursor behavior.
- Serialize live stream flushes and allocate chunk indexes atomically.
- Deduplicate identical service routing URLs and clarify that selected registrations do not identify executing pods.
- Add database migrations and regression coverage for queue, stream, pagination, and routing behavior.

## Review Guide

1. Review queue failure finalization in `packages/workflow/queue/poller.ts`, especially v4 step queues versus v5 workflow-queue background steps.
2. Check dead-letter retry semantics in `packages/workflow/plugins/dead-letters.ts`: historical messages without finalized failures remain retryable, while messages with finalized failures do not.
3. Review migration `005` carefully because it renumbers existing stream chunks, removes duplicate close markers, and takes an exclusive table lock.
4. Confirm stream advisory-lock scope matches `(application_id, run_id, stream_name)`.
5. Check event cursor semantics for final pages, empty incremental reads, and descending traversal.
6. Confirm routing documentation accurately describes service-level routing; pod-specific execution still depends on Desk/ICC registering directly routable endpoints.

Assisted-By: OpenAI:GPT-5.6-sol <openai/gpt-5.6-sol>
