### PR TITLE
fix: Improve world compatibility.

### DIFF
--- a/e2e-v4/test/cbor-e2e.test.ts
+++ b/e2e-v4/test/cbor-e2e.test.ts
@@ -1,7 +1,7 @@
 // Same CBOR ground-truth assertions as e2e-v5/test/cbor-e2e.test.ts, but
 // exercising the v4 SDK path (workflow@4.2.4 → @workflow/core@4.2.4 →
 // @workflow/world@4.1.1). CBOR was backported to v4.1.0-beta.17, so a v4
-// SDK also passes specVersion=3 to world.queue() and the DB rows should
+// SDK passes the world's advertised specVersion to world.queue() and the DB rows should
 // come out as payload_encoding='cbor'.
 
 import { test, before, after } from 'node:test'
@@ -19,14 +19,14 @@ before(async () => {
 
 after(() => ctx?.kill())
 
-test('v4: world declares specVersion = SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT', () => {
+test('v4: world advertises attributes while retaining CBOR support', () => {
   const world = createPlatformaticWorld({
     serviceUrl: ctx.wfUrl,
     appId: 'default',
     deploymentVersion: DEPLOYMENT_VERSION,
   })
-  assert.equal(world.specVersion, SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
-  assert.equal(world.specVersion, 3)
+  assert.ok(world.specVersion >= SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
+  assert.equal(world.specVersion, 4)
 })
 
 test('v4: health endpoint reports specVersion >= SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT', { timeout: 10_000 }, async () => {
@@ -40,7 +40,7 @@ test('v4: health endpoint reports specVersion >= SPEC_VERSION_SUPPORTS_CBOR_QUEU
 test('v4: workflow run enqueues messages with payload_encoding=cbor', { timeout: 30_000 }, async () => {
   // Run addTenWorkflow end-to-end and verify the DB has CBOR rows — the
   // ground-truth signal that the v4 SDK negotiated CBOR with our world
-  // via world.specVersion=3 and sent application/cbor bodies.
+  // via world.specVersion=4 and sent application/cbor bodies.
   const res = await fetch(`${ctx.nextUrl}/api/trigger`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },

--- a/e2e-v5/app/api/trigger/route.ts
+++ b/e2e-v5/app/api/trigger/route.ts
@@ -4,6 +4,8 @@ import { NextResponse } from 'next/server'
 
 export async function POST (request: Request) {
   const { name } = await request.json() as { name: string }
-  const run = await start(greet, [name])
+  const run = await start(greet, [name], {
+    attributes: { initial: 'present', remove: 'old' }
+  })
   return NextResponse.json({ runId: run.runId })
 }

--- a/e2e-v5/test/cbor-e2e.test.ts
+++ b/e2e-v5/test/cbor-e2e.test.ts
@@ -18,14 +18,14 @@ before(async () => {
 
 after(() => teardown(wfService, nextApp))
 
-test('world declares specVersion = SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT', () => {
+test('world advertises attributes while retaining CBOR support', () => {
   const world = createPlatformaticWorld({
     serviceUrl: WF_URL,
     appId: 'default',
     deploymentVersion: DEPLOYMENT_VERSION,
   })
-  assert.equal(world.specVersion, SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
-  assert.equal(world.specVersion, 3)
+  assert.ok(world.specVersion >= SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
+  assert.equal(world.specVersion, 4)
 })
 
 test('health endpoint reports specVersion >= SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT', { timeout: 10_000 }, async () => {
@@ -69,6 +69,17 @@ test('workflow run enqueues messages with payload_encoding=cbor', { timeout: 30_
       assert.equal(row.payload_null, true, 'payload JSONB must be null for CBOR row')
       assert.equal(row.bytes_present, true, 'payload_bytes must be present for CBOR row')
     }
+
+    const run = await client.query('SELECT spec_version, attributes FROM workflow_runs WHERE id = $1', [runId])
+    assert.equal(run.rows[0].spec_version, 4)
+    assert.deepEqual(run.rows[0].attributes, { initial: 'present', updated: 'yes' })
+
+    const attributes = await client.query(
+      `SELECT event_data FROM workflow_events
+       WHERE run_id = $1 AND event_type = 'attr_set'`,
+      [runId]
+    )
+    assert.equal(attributes.rows.length, 1)
   } finally {
     await client.end()
   }

--- a/e2e-v5/workflows/greet.ts
+++ b/e2e-v5/workflows/greet.ts
@@ -1,6 +1,9 @@
+import { experimental_setAttributes as setAttributes } from 'workflow'
+
 export async function greet (name: string) {
   'use workflow'
   const message = await buildGreeting(name)
+  await setAttributes({ updated: 'yes', remove: undefined })
   return { message }
 }
 

--- a/packages/workflow/migrations/007.do.sql
+++ b/packages/workflow/migrations/007.do.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workflow_runs
+  ADD COLUMN attributes JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/packages/workflow/migrations/007.undo.sql
+++ b/packages/workflow/migrations/007.undo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workflow_runs DROP COLUMN attributes;

--- a/packages/workflow/plugins/events.ts
+++ b/packages/workflow/plugins/events.ts
@@ -5,6 +5,71 @@ import { RunNotFound, BadRequest } from '../lib/errors.ts'
 import { checkRunQuota, checkEventQuota } from '../lib/quotas.ts'
 import type pg from 'pg'
 
+const ATTRIBUTE_KEY_MAX_LENGTH = 256
+const ATTRIBUTE_VALUE_MAX_BYTES = 256
+const ATTRIBUTE_MAX_PER_RUN = 64
+
+function validateAttribute (key: string, value: string, allowReservedAttributes: boolean): void {
+  if (key.length === 0) throw new BadRequest('attribute key must not be empty')
+  if (key.length > ATTRIBUTE_KEY_MAX_LENGTH) throw new BadRequest(`attribute key length exceeds limit ${ATTRIBUTE_KEY_MAX_LENGTH}`)
+  if (!allowReservedAttributes && key.startsWith('$')) throw new BadRequest(`attribute key ${JSON.stringify(key)} uses reserved prefix "$"`)
+  if (Buffer.byteLength(value, 'utf8') > ATTRIBUTE_VALUE_MAX_BYTES) {
+    throw new BadRequest(`attribute value byte length exceeds limit ${ATTRIBUTE_VALUE_MAX_BYTES}`)
+  }
+}
+
+function validateAttributes (attributes: unknown, allowReservedAttributes: boolean): Record<string, string> {
+  if (attributes === undefined) return {}
+  if (!attributes || typeof attributes !== 'object' || Array.isArray(attributes)) {
+    throw new BadRequest('attributes must be an object')
+  }
+
+  const entries = Object.entries(attributes)
+  if (entries.length > ATTRIBUTE_MAX_PER_RUN) {
+    throw new BadRequest(`run attribute count would exceed limit ${ATTRIBUTE_MAX_PER_RUN}`)
+  }
+  for (const [key, value] of entries) {
+    if (typeof value !== 'string') throw new BadRequest('attribute value must be a string')
+    validateAttribute(key, value, allowReservedAttributes)
+  }
+  return Object.fromEntries(entries)
+}
+
+function applyAttributeChanges (existing: Record<string, string>, eventData: any): Record<string, string> {
+  const changes = eventData?.changes
+  if (!Array.isArray(changes)) throw new BadRequest('attribute changes must be an array')
+  if (changes.length === 0) throw new BadRequest('attribute changes must not be empty')
+  const writer = eventData?.writer
+  if (!writer || typeof writer !== 'object' || Array.isArray(writer)) throw new BadRequest('attribute writer must be workflow or step')
+  if (writer.type === 'workflow') {
+    if (Object.keys(writer).length !== 1) throw new BadRequest('workflow attribute writer only accepts type')
+  } else if (writer.type === 'step') {
+    if (Object.keys(writer).some(key => !['type', 'stepId', 'attempt'].includes(key)) ||
+        typeof writer.stepId !== 'string' || writer.stepId.length === 0 ||
+        !Number.isInteger(writer.attempt) || writer.attempt < 1) {
+      throw new BadRequest('step attribute writer requires a nonempty stepId and positive integer attempt')
+    }
+  } else {
+    throw new BadRequest('attribute writer must be workflow or step')
+  }
+
+  const seen = new Set<string>()
+  const next = { ...existing }
+  for (const change of changes) {
+    if (!change || typeof change !== 'object' || Array.isArray(change) || typeof change.key !== 'string' ||
+        (typeof change.value !== 'string' && change.value !== null)) {
+      throw new BadRequest('attribute changes require a string key and string or null value')
+    }
+    if (seen.has(change.key)) throw new BadRequest(`attribute key ${JSON.stringify(change.key)} appears more than once`)
+    seen.add(change.key)
+    validateAttribute(change.key, change.value === null ? '' : change.value, eventData.allowReservedAttributes === true)
+    if (change.value === null) delete next[change.key]
+    else next[change.key] = change.value
+  }
+  // Existing reserved keys remain valid; reservation policy applies only to changed keys.
+  return validateAttributes(next, true)
+}
+
 // Encode data as binary for storage. Supports both Uint8Array (base64) and JSON.
 function encodeData (data: unknown): Buffer | null {
   if (data === undefined || data === null) return null
@@ -45,6 +110,8 @@ function formatEvent (row: any, resolveData?: string) {
   if (row.correlation_id) event.correlationId = row.correlation_id
   if (resolveData !== 'none' && row.event_data) {
     event.eventData = decodeData(row.event_data)
+  } else if (resolveData === 'none' && row.event_type === 'attr_set' && row.event_data) {
+    event.eventData = decodeData(row.event_data)
   }
   return event
 }
@@ -58,6 +125,7 @@ function formatRun (row: any, resolveData?: string) {
     specVersion: row.spec_version,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    attributes: row.attributes || {},
   }
   if (resolveData !== 'none') {
     run.input = decodeData(row.input)
@@ -232,6 +300,10 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
           const runId = rawRunId === 'null' ? randomUUID() : rawRunId
           const eventData = body.eventData || {}
           const input = encodeData(eventData.input)
+          if (eventData.attributes !== undefined && (!Number.isInteger(body.specVersion) || body.specVersion < 4)) {
+            throw new BadRequest('initial attributes require specVersion 4 or newer')
+          }
+          const attributes = validateAttributes(eventData.attributes, eventData.allowReservedAttributes === true)
 
           // Idempotent: the SDK retries this endpoint on transient errors
           // (network blip, timeout, 5xx). A duplicate POST for the same runId
@@ -239,11 +311,11 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
           // existing run state instead. Mirrors the run_started handler's
           // existence-check pattern, just via an atomic upsert.
           const inserted = await client.query(
-            `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, input, execution_context, spec_version)
-             VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7)
+            `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, input, execution_context, spec_version, attributes)
+             VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7, $8)
              ON CONFLICT (id) DO NOTHING
              RETURNING id`,
-            [runId, appId, eventData.workflowName, eventData.deploymentId, input, eventData.executionContext || null, body.specVersion || null]
+            [runId, appId, eventData.workflowName, eventData.deploymentId, input, eventData.executionContext || null, body.specVersion || null, attributes]
           )
 
           // Only emit the run_created event row when we actually created the
@@ -290,14 +362,23 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
               throw new RunNotFound(rawRunId)
             }
             const input = eventData.input ? encodeData(eventData.input) : null
+            if (eventData.attributes !== undefined && (!Number.isInteger(body.specVersion) || body.specVersion < 4)) {
+              throw new BadRequest('initial attributes require specVersion 4 or newer')
+            }
+            const attributes = validateAttributes(eventData.attributes, eventData.allowReservedAttributes === true)
             await client.query(
               `INSERT INTO workflow_runs
                  (id, application_id, workflow_name, deployment_id, status,
-                  input, execution_context, spec_version, started_at)
-               VALUES ($1, $2, $3, $4, 'running', $5, $6, $7, NOW())`,
+                   input, execution_context, spec_version, started_at, attributes)
+               VALUES ($1, $2, $3, $4, 'running', $5, $6, $7, NOW(), $8)`,
               [rawRunId, appId, eventData.workflowName, eventData.deploymentId,
-                input, eventData.executionContext || null, body.specVersion || null]
+                input, eventData.executionContext || null, body.specVersion || null, attributes]
             )
+
+            await insertEvent(client, rawRunId, appId, {
+              ...body,
+              eventType: 'run_created'
+            })
           }
 
           // Dedupe run_started: exactly one event per run in the log, otherwise
@@ -324,6 +405,43 @@ async function eventsPlugin (app: FastifyInstance): Promise<void> {
           const runRow = (await client.query('SELECT * FROM workflow_runs WHERE id = $1', [rawRunId])).rows[0]
           if (!runRow) throw new RunNotFound(rawRunId)
           result = { event: eventRow ? formatEvent(eventRow, resolveData) : null, run: formatRun(runRow, resolveData) }
+          break
+        }
+
+        case 'attr_set': {
+          const runResult = await client.query(
+            'SELECT * FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
+            [rawRunId, appId]
+          )
+          if (runResult.rows.length === 0) throw new RunNotFound(rawRunId)
+          if (!Number.isInteger(body.specVersion) || body.specVersion < 4 ||
+              !Number.isInteger(runResult.rows[0].spec_version) || runResult.rows[0].spec_version < 4) {
+            throw new BadRequest('attr_set requires a specVersion 4 run')
+          }
+
+          if (body.correlationId) {
+            const duplicate = await client.query(
+              `SELECT * FROM workflow_events
+               WHERE run_id = $1 AND application_id = $2 AND event_type = 'attr_set' AND correlation_id = $3
+               ORDER BY id ASC LIMIT 1`,
+              [rawRunId, appId, body.correlationId]
+            )
+            if (duplicate.rows.length > 0) {
+              result = { event: formatEvent(duplicate.rows[0], resolveData), run: formatRun(runResult.rows[0], resolveData) }
+              break
+            }
+          }
+
+          if (runResult.rows[0].status !== 'pending' && runResult.rows[0].status !== 'running') {
+            throw new BadRequest(`run is already in terminal state: ${runResult.rows[0].status}`)
+          }
+          const attributes = applyAttributeChanges(runResult.rows[0].attributes || {}, body.eventData)
+          const updatedRun = await client.query(
+            'UPDATE workflow_runs SET attributes = $3, updated_at = NOW() WHERE id = $1 AND application_id = $2 RETURNING *',
+            [rawRunId, appId, attributes]
+          )
+          const eventRow = await insertEvent(client, rawRunId, appId, body)
+          result = { event: formatEvent(eventRow, resolveData), run: formatRun(updatedRun.rows[0], resolveData) }
           break
         }
 

--- a/packages/workflow/plugins/run-actions.ts
+++ b/packages/workflow/plugins/run-actions.ts
@@ -44,8 +44,15 @@ async function runActionsPlugin (app: FastifyInstance): Promise<void> {
         }), row.spec_version]
       )
 
-      // Enqueue flow message targeting the original deployment version
-      const queueName = `__wkf_workflow_${row.workflow_name}`
+      // Preserve the namespace used by the original run when one was persisted.
+      const originalQueue = await client.query(
+        `SELECT queue_name FROM workflow_queue_messages
+         WHERE run_id = $1 AND application_id = $2
+           AND queue_name ~ '^__([a-z][a-z0-9]*_)?wkf_workflow_.+$'
+         ORDER BY id ASC LIMIT 1`,
+        [runId, appId]
+      )
+      const queueName = originalQueue.rows[0]?.queue_name || `__wkf_workflow_${row.workflow_name}`
       await client.query(
         `INSERT INTO workflow_queue_messages
          (queue_name, run_id, deployment_version, application_id, payload, status)
@@ -153,7 +160,7 @@ async function runActionsPlugin (app: FastifyInstance): Promise<void> {
       await app.pg.query(
         `UPDATE workflow_queue_messages SET status = 'pending', deliver_at = NULL
          WHERE run_id = $1 AND application_id = $2 AND status = 'deferred'
-           AND queue_name LIKE '__wkf_step_%'`,
+           AND queue_name ~ '^__([a-z][a-z0-9]*_)?wkf_(workflow|step)_.+$'`,
         [runId, appId]
       )
       await app.pg.query("SELECT pg_notify('deferred_messages', '{}')")

--- a/packages/workflow/queue/router.ts
+++ b/packages/workflow/queue/router.ts
@@ -31,9 +31,10 @@ export async function routeMessage (
 
   if (registrations.rows.length === 0) return null
 
-  const urlField = queueName.startsWith('__wkf_step_')
+  const queueMatch = queueName.match(/^__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_.+$/)
+  const urlField = queueMatch?.[1] === 'step'
     ? 'step_url'
-    : queueName.startsWith('__wkf_workflow_') ? 'workflow_url' : 'webhook_url'
+    : queueMatch?.[1] === 'workflow' ? 'workflow_url' : 'webhook_url'
   const urls = [...new Set(registrations.rows.map(registration => registration[urlField]))]
   const url = urls[Math.floor(Math.random() * urls.length)]
 

--- a/packages/workflow/test/events.test.ts
+++ b/packages/workflow/test/events.test.ts
@@ -39,6 +39,7 @@ describe('events', () => {
     assert.equal(body.run.status, 'pending')
     assert.equal(body.run.workflowName, 'test-workflow')
     assert.equal(body.run.deploymentId, 'v1.0.0')
+    assert.deepEqual(body.run.attributes, {})
     assert.ok(body.run.runId)
   })
 
@@ -183,6 +184,208 @@ describe('events', () => {
     })
     const events = JSON.parse(eventsRes.body)
     assert.equal(events.data.length, 6) // run_created, run_started, step_created, step_started, step_completed, run_completed
+  })
+
+  it('should persist initial attributes and atomically apply attr_set events', async () => {
+    const create = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      payload: {
+        eventType: 'run_created',
+        specVersion: 4,
+        eventData: {
+          deploymentId: 'v4',
+          workflowName: 'attributes-test',
+          input: {},
+          attributes: { keep: 'yes', remove: 'old' }
+        }
+      }
+    })
+    assert.equal(create.statusCode, 200)
+    const runId = JSON.parse(create.body).run.runId
+    const update = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events?resolveData=none`,
+      payload: {
+        eventType: 'attr_set',
+        correlationId: 'attrs-1',
+        specVersion: 4,
+        eventData: {
+          changes: [{ key: 'added', value: 'new' }, { key: 'remove', value: null }],
+          writer: { type: 'workflow' }
+        }
+      }
+    })
+    assert.equal(update.statusCode, 200)
+    const updated = JSON.parse(update.body)
+    assert.deepEqual(updated.run.attributes, { keep: 'yes', added: 'new' })
+    assert.equal(updated.event.eventData.writer.type, 'workflow')
+    assert.equal(updated.event.eventData.changes[0].key, 'added')
+
+    const duplicate = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      payload: {
+        eventType: 'attr_set',
+        correlationId: 'attrs-1',
+        specVersion: 4,
+        eventData: {
+          changes: [{ key: 'added', value: 'different' }],
+          writer: { type: 'workflow' }
+        }
+      }
+    })
+    assert.equal(duplicate.statusCode, 200)
+    assert.deepEqual(JSON.parse(duplicate.body).run.attributes, { keep: 'yes', added: 'new' })
+  })
+
+  it('should validate attributes and reject terminal-run writes', async () => {
+    const invalid = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      payload: {
+        eventType: 'run_created',
+        specVersion: 4,
+        eventData: { deploymentId: 'v4', workflowName: 'invalid-attributes', input: {}, attributes: { $reserved: 'no' } }
+      }
+    })
+    assert.equal(invalid.statusCode, 400)
+
+    const allowed = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      payload: {
+        eventType: 'run_created',
+        specVersion: 4,
+        eventData: {
+          deploymentId: 'v4',
+          workflowName: 'allowed-attributes',
+          input: {},
+          attributes: { $system: 'yes' },
+          allowReservedAttributes: true
+        }
+      }
+    })
+    assert.equal(allowed.statusCode, 200)
+    const runId = JSON.parse(allowed.body).run.runId
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      payload: { eventType: 'run_completed', specVersion: 4, eventData: { output: {} } }
+    })
+    const terminal = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      payload: {
+        eventType: 'attr_set',
+        specVersion: 4,
+        eventData: { changes: [{ key: 'late', value: 'no' }], writer: { type: 'step', stepId: 's1', attempt: 1 } }
+      }
+    })
+    assert.equal(terminal.statusCode, 400)
+  })
+
+  it('should restore initial attributes during resilient run_started', async () => {
+    const runId = `wrun_resilient_attrs_${randomBytes(8).toString('hex')}`
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      payload: {
+        eventType: 'run_started',
+        specVersion: 4,
+        eventData: {
+          deploymentId: 'v4',
+          workflowName: 'resilient-attributes',
+          input: {},
+          attributes: { restored: 'yes' }
+        }
+      }
+    })
+    assert.equal(response.statusCode, 200)
+    assert.deepEqual(JSON.parse(response.body).run.attributes, { restored: 'yes' })
+
+    const events = await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`
+    })
+    assert.equal(events.statusCode, 200)
+    assert.deepEqual(JSON.parse(events.body).data.map((event: any) => event.eventType), ['run_created', 'run_started'])
+  })
+
+  it('should reject attributes for spec 3 runs', async () => {
+    const invalidCreate = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      payload: {
+        eventType: 'run_created',
+        specVersion: 3,
+        eventData: {
+          deploymentId: 'v3',
+          workflowName: 'spec-3-attributes',
+          input: {},
+          attributes: { unsupported: 'true' }
+        }
+      }
+    })
+    assert.equal(invalidCreate.statusCode, 400)
+
+    const create = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      payload: {
+        eventType: 'run_created',
+        specVersion: 3,
+        eventData: { deploymentId: 'v3', workflowName: 'spec-3-run', input: {} }
+      }
+    })
+    assert.equal(create.statusCode, 200)
+    const runId = JSON.parse(create.body).run.runId
+    const update = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      payload: {
+        eventType: 'attr_set',
+        specVersion: 4,
+        eventData: {
+          changes: [{ key: 'unsupported', value: 'true' }],
+          writer: { type: 'workflow' }
+        }
+      }
+    })
+    assert.equal(update.statusCode, 400)
+  })
+
+  it('should reject invalid attr_set batches', async () => {
+    const create = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      payload: {
+        eventType: 'run_created',
+        specVersion: 4,
+        eventData: { deploymentId: 'v4', workflowName: 'attribute-validation', input: {} }
+      }
+    })
+    const runId = JSON.parse(create.body).run.runId
+    const invalidChanges = [
+      [{ key: 'duplicate', value: 'one' }, { key: 'duplicate', value: 'two' }],
+      [{ key: 'wrong-value', value: 1 }],
+      [{ key: 'x'.repeat(257), value: 'too-long' }],
+      [{ key: 'large', value: 'x'.repeat(257) }],
+      Array.from({ length: 65 }, (_, index) => ({ key: `key-${index}`, value: 'value' }))
+    ]
+
+    for (const changes of invalidChanges) {
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+        payload: {
+          eventType: 'attr_set',
+          specVersion: 4,
+          eventData: { changes, writer: { type: 'workflow' } }
+        }
+      })
+      assert.equal(response.statusCode, 400)
+    }
   })
 
   it('should handle hook_created with token conflict', async () => {

--- a/packages/workflow/test/router.test.ts
+++ b/packages/workflow/test/router.test.ts
@@ -13,26 +13,26 @@ describe('queue router', () => {
             {
               workflow_url: 'http://service-a/flow',
               step_url: 'http://service-a/step',
-              webhook_url: 'http://service-a/webhook',
+              webhook_url: 'http://service-a/webhook'
             },
             {
               workflow_url: 'http://service-a/flow',
               step_url: 'http://service-a/step',
-              webhook_url: 'http://service-a/webhook',
+              webhook_url: 'http://service-a/webhook'
             },
             {
               workflow_url: 'http://service-a/flow',
               step_url: 'http://service-a/step',
-              webhook_url: 'http://service-a/webhook',
+              webhook_url: 'http://service-a/webhook'
             },
             {
               workflow_url: 'http://service-b/flow',
               step_url: 'http://service-b/step',
-              webhook_url: 'http://service-b/webhook',
-            },
-          ],
+              webhook_url: 'http://service-b/webhook'
+            }
+          ]
         }
-      },
+      }
     } as unknown as pg.Pool
     const random = Math.random
     Math.random = () => 0.75
@@ -53,14 +53,18 @@ describe('queue router', () => {
           rows: [{
             workflow_url: 'http://service/flow',
             step_url: 'http://service/step',
-            webhook_url: 'http://service/webhook',
-          }],
+            webhook_url: 'http://service/webhook'
+          }]
         }
-      },
+      }
     } as unknown as pg.Pool
 
     assert.deepEqual(await routeMessage(pool, 1, 'v1', '__wkf_step_test'), { url: 'http://service/step' })
     assert.deepEqual(await routeMessage(pool, 1, 'v1', '__wkf_workflow_test'), { url: 'http://service/flow' })
+    assert.deepEqual(await routeMessage(pool, 1, 'v1', '__tenant1_wkf_step_test'), { url: 'http://service/step' })
+    assert.deepEqual(await routeMessage(pool, 1, 'v1', '__tenant1_wkf_workflow_test'), { url: 'http://service/flow' })
+    assert.deepEqual(await routeMessage(pool, 1, 'v1', '__Tenant_wkf_step_test'), { url: 'http://service/webhook' })
+    assert.deepEqual(await routeMessage(pool, 1, 'v1', '__tenant-name_wkf_workflow_test'), { url: 'http://service/webhook' })
     assert.deepEqual(await routeMessage(pool, 1, 'v1', 'webhook'), { url: 'http://service/webhook' })
   })
 })

--- a/packages/workflow/test/run-actions.test.ts
+++ b/packages/workflow/test/run-actions.test.ts
@@ -113,6 +113,29 @@ describe('run-actions', () => {
     assert.equal(messages.rows[0].status, 'pending')
   })
 
+  it('should preserve a namespaced workflow queue when replaying', async () => {
+    const run = await createRun('v1', 'namespaced-replay')
+    await startRun(run.runId)
+    await completeRun(run.runId)
+    const app = await ctx.app.pg.query('SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId])
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_queue_messages
+       (queue_name, run_id, deployment_version, application_id, payload, status)
+       VALUES ($1, $2, 'v1', $3, '{}', 'completed')`,
+      ['__tenant1_wkf_workflow_namespaced-replay', run.runId, app.rows[0].id]
+    )
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${run.runId}/replay`,
+      payload: {}
+    })
+    assert.equal(response.statusCode, 200)
+    const replayed = JSON.parse(response.body)
+    const messages = await ctx.app.pg.query('SELECT queue_name FROM workflow_queue_messages WHERE run_id = $1', [replayed.runId])
+    assert.equal(messages.rows[0].queue_name, '__tenant1_wkf_workflow_namespaced-replay')
+  })
+
   it('should return 404 for non-existent run', async () => {
     const response = await ctx.app.inject({
       method: 'POST',
@@ -176,5 +199,37 @@ describe('run-actions', () => {
     assert.equal(response.statusCode, 200)
     const body = JSON.parse(response.body)
     assert.equal(body.stoppedCount, 1)
+  })
+
+  it('should promote namespaced workflow and step queues on wake-up', async () => {
+    const run = await createRun('v1', 'namespaced-wake-up')
+    await startRun(run.runId)
+    await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${run.runId}/events`,
+      payload: {
+        eventType: 'wait_created',
+        correlationId: 'sleep-namespaced',
+        specVersion: 3,
+        eventData: { resumeAt: new Date(Date.now() + 60000).toISOString() }
+      }
+    })
+    const app = await ctx.app.pg.query('SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId])
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_queue_messages
+       (queue_name, run_id, deployment_version, application_id, payload, status, deliver_at)
+       VALUES ($1, $2, 'v1', $3, '{}', 'deferred', NOW() + INTERVAL '1 minute')`,
+      ['__tenant1_wkf_workflow_namespaced-wake-up', run.runId, app.rows[0].id]
+    )
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${run.runId}/wake-up`,
+      payload: {}
+    })
+    assert.equal(response.statusCode, 200)
+    const message = await ctx.app.pg.query('SELECT status, deliver_at FROM workflow_queue_messages WHERE run_id = $1', [run.runId])
+    assert.equal(message.rows[0].status, 'pending')
+    assert.equal(message.rows[0].deliver_at, null)
   })
 })

--- a/packages/workflow/watt-test.json
+++ b/packages/workflow/watt-test.json
@@ -8,7 +8,8 @@
   "runtime": {
     "metrics": {
       "enabled": false
-    }
+    },
+    "healthProbes": false
   },
   "plugins": {
     "paths": ["./dist/plugins"]

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { getSharedContext } from '@platformatic/globals'
 import type { World } from '@workflow/world'
-import { SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT } from '@workflow/world'
 import { HttpClient } from './lib/client.ts'
 import type { ClientConfig } from './lib/client.ts'
 import { createStorage } from './lib/storage.ts'
@@ -13,11 +12,13 @@ import { createEncryption } from './lib/encryption.ts'
 
 export interface PlatformaticWorldConfig extends ClientConfig, QueueConfig {}
 
+const SPEC_VERSION_SUPPORTS_ATTRIBUTES = 4
+
 export function createPlatformaticWorld (config: PlatformaticWorldConfig): World {
   const client = new HttpClient(config)
 
   return {
-    specVersion: SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT,
+    specVersion: SPEC_VERSION_SUPPORTS_ATTRIBUTES,
     ...createStorage(client),
     ...createQueue(client, config),
     ...createStreamer(client),
@@ -100,7 +101,12 @@ export function createWorld (options?: Partial<CreateWorldOptions>): World {
     throw new Error('PLT_WORLD_SERVICE_URL environment variable is required')
   }
 
-  const appId = options?.appId || process.env.PLT_WORLD_APP_ID || readAppName()
+  const runningInK8s = isRunningInK8s()
+  const explicitAppId = options?.appId || process.env.PLT_WORLD_APP_ID
+  if (runningInK8s && !explicitAppId) {
+    throw new Error('World application ID is required in Kubernetes; set options.appId or PLT_WORLD_APP_ID')
+  }
+  const appId = explicitAppId || readAppName()
   const explicitVersion = options?.deploymentVersion ||
     process.env.PLT_WORLD_DEPLOYMENT_VERSION ||
     process.env.PLT_DEPLOYMENT_VERSION
@@ -112,7 +118,7 @@ export function createWorld (options?: Partial<CreateWorldOptions>): World {
     deploymentVersion: explicitVersion || 'local',
     // In K8s ICC assigns the version, so a 'local' stamp means "not resolved yet" and
     // must not be used to enqueue (see queue.ts). Standalone/local dev keeps 'local'.
-    requireResolvedVersion: isRunningInK8s(),
+    requireResolvedVersion: runningInK8s,
   }
 
   // No explicit version: start at 'local'. When running inside a watt runtime, the

--- a/packages/world/src/lib/client.ts
+++ b/packages/world/src/lib/client.ts
@@ -22,8 +22,10 @@ function createAPIError (statusCode: number, text: string): Error {
     // Not JSON
   }
   const err: any = new Error(`HTTP ${statusCode}: ${text}`)
-  // Only set WorkflowAPIError name for specific status codes the SDK expects
-  if (statusCode === 409 || statusCode === 410 || statusCode === 425 || statusCode === 429) {
+  // SDK 5 recognizes deterministic validation failures through this structural name.
+  if (statusCode === 400) {
+    err.name = 'WorkflowWorldError'
+  } else if (statusCode === 409 || statusCode === 410 || statusCode === 425 || statusCode === 429) {
     err.name = 'WorkflowAPIError'
   }
   err.status = statusCode

--- a/packages/world/src/lib/queue.ts
+++ b/packages/world/src/lib/queue.ts
@@ -69,7 +69,11 @@ export function createQueue (client: HttpClient, config: QueueConfig) {
     }
   }
 
-  const createQueueHandler = (_prefix: string, handler: (message: unknown, meta: { attempt: number; queueName: ValidQueueName; messageId: MessageId }) => Promise<void | { timeoutSeconds: number }>) => {
+  const createQueueHandler = (prefix: string, handler: (message: unknown, meta: { attempt: number; queueName: ValidQueueName; messageId: MessageId }) => Promise<void | { timeoutSeconds: number }>) => {
+    if (!/^__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_$/.test(prefix)) {
+      throw new Error(`Invalid queue prefix: ${prefix}`)
+    }
+
     return async (req: Request): Promise<Response> => {
       const contentType = req.headers.get('content-type') || ''
       let body: { message: unknown; meta: { queueName: ValidQueueName; messageId: MessageId; attempt: number } }
@@ -87,7 +91,14 @@ export function createQueue (client: HttpClient, config: QueueConfig) {
         body = await req.json() as typeof body
       }
 
-      const result = await handler(body.message, body.meta)
+      const meta = body?.meta
+      if (!meta || typeof meta.queueName !== 'string' || !meta.queueName.startsWith(prefix) ||
+          !/^__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_.+$/.test(meta.queueName) ||
+          typeof meta.messageId !== 'string' || typeof meta.attempt !== 'number' || !Number.isFinite(meta.attempt)) {
+        return Response.json({ error: 'Invalid queue message metadata' }, { status: 400 })
+      }
+
+      const result = await handler(body.message, meta)
 
       // The queue service handles re-queuing based on the timeoutSeconds in the response.
       // Do not re-queue here to avoid creating duplicate deferred messages.

--- a/packages/world/src/lib/queue.ts
+++ b/packages/world/src/lib/queue.ts
@@ -73,6 +73,9 @@ export function createQueue (client: HttpClient, config: QueueConfig) {
     if (!/^__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_$/.test(prefix)) {
       throw new Error(`Invalid queue prefix: ${prefix}`)
     }
+    const alternatePrefix = prefix.endsWith('workflow_')
+      ? prefix.replace(/workflow_$/, 'step_')
+      : prefix.replace(/step_$/, 'workflow_')
 
     return async (req: Request): Promise<Response> => {
       const contentType = req.headers.get('content-type') || ''
@@ -92,7 +95,11 @@ export function createQueue (client: HttpClient, config: QueueConfig) {
       }
 
       const meta = body?.meta
-      if (!meta || typeof meta.queueName !== 'string' || !meta.queueName.startsWith(prefix) ||
+      const isHealthCheck = typeof body?.message === 'object' && body.message !== null &&
+        (body.message as { __healthCheck?: unknown }).__healthCheck === true
+      const prefixMatches = typeof meta?.queueName === 'string' &&
+        (meta.queueName.startsWith(prefix) || (isHealthCheck && meta.queueName === `${alternatePrefix}health_check`))
+      if (!meta || !prefixMatches ||
           !/^__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_.+$/.test(meta.queueName) ||
           typeof meta.messageId !== 'string' || typeof meta.attempt !== 'number' || !Number.isFinite(meta.attempt)) {
         return Response.json({ error: 'Invalid queue message metadata' }, { status: 400 })

--- a/packages/world/test/queue.test.ts
+++ b/packages/world/test/queue.test.ts
@@ -228,6 +228,30 @@ test('createQueueHandler accepts a namespaced prefix and rejects mismatched meta
   await world.close!()
 })
 
+test('createQueueHandler accepts a health check for the alternate endpoint', async () => {
+  const world = createPlatformaticWorld({
+    serviceUrl: 'http://localhost:9999',
+    appId: 'app',
+    deploymentVersion: 'v1'
+  })
+  let handled = false
+  const handler = world.createQueueHandler('__wkf_workflow_' as any, async () => {
+    handled = true
+  })
+  const response = await handler(new Request('http://localhost/flow', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      message: { __healthCheck: true, correlationId: 'health-check' },
+      meta: { queueName: '__wkf_step_health_check', messageId: 'm5', attempt: 1 }
+    })
+  }))
+
+  assert.equal(response.status, 200)
+  assert.equal(handled, true)
+  await world.close!()
+})
+
 test('world declares specVersion 4', () => {
   const world = createPlatformaticWorld({
     serviceUrl: 'http://localhost:9999',

--- a/packages/world/test/queue.test.ts
+++ b/packages/world/test/queue.test.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from 'node:net'
 import { decode, encode } from 'cbor-x'
 import { SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT } from '@workflow/world'
 import { createPlatformaticWorld } from '../src/index.ts'
+import { HttpClient } from '../src/lib/client.ts'
 
 interface RecordedRequest {
   contentType: string
@@ -197,12 +198,61 @@ test('createQueueHandler accepts CBOR', async () => {
   await world.close!()
 })
 
-test('world declares specVersion 3', () => {
+test('createQueueHandler accepts a namespaced prefix and rejects mismatched metadata', async () => {
+  const world = createPlatformaticWorld({
+    serviceUrl: 'http://localhost:9999',
+    appId: 'app',
+    deploymentVersion: 'v1'
+  })
+  const handler = world.createQueueHandler('__tenant1_wkf_step_' as any, async () => {})
+  const valid = await handler(new Request('http://localhost/step', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      message: {},
+      meta: { queueName: '__tenant1_wkf_step_name', messageId: 'm3', attempt: 1 }
+    })
+  }))
+  assert.equal(valid.status, 200)
+
+  const invalid = await handler(new Request('http://localhost/step', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      message: {},
+      meta: { queueName: '__wkf_step_name', messageId: 'm4', attempt: 1 }
+    })
+  }))
+  assert.equal(invalid.status, 400)
+  assert.throws(() => world.createQueueHandler('__Tenant_wkf_step_' as any, async () => {}), /Invalid queue prefix/)
+  await world.close!()
+})
+
+test('world declares specVersion 4', () => {
   const world = createPlatformaticWorld({
     serviceUrl: 'http://localhost:9999',
     appId: 'app',
     deploymentVersion: 'v1',
   })
-  assert.equal(world.specVersion, SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
-  assert.equal(world.specVersion, 3)
+  assert.ok(world.specVersion > SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
+  assert.equal(world.specVersion, 4)
+})
+
+test('HTTP 400 errors are classified as WorkflowWorldError', async () => {
+  const server = createServer((_req, res) => {
+    res.writeHead(400, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ message: 'invalid attributes' }))
+  })
+  await new Promise<void>(resolve => server.listen(0, resolve))
+  const port = (server.address() as AddressInfo).port
+  const client = new HttpClient({ serviceUrl: `http://localhost:${port}`, appId: 'app' })
+  try {
+    await assert.rejects(
+      () => client.post('/runs/run/events', {}),
+      (err: any) => err.name === 'WorkflowWorldError' && err.status === 400
+    )
+  } finally {
+    await client.close()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  }
 })

--- a/packages/world/test/world.test.ts
+++ b/packages/world/test/world.test.ts
@@ -64,6 +64,35 @@ test('reads from env vars', async () => {
   }
 })
 
+test('requires an explicit application ID in Kubernetes', async () => {
+  const fakeSaDir = join(tmpdir(), `plt-world-app-id-test-${process.pid}`)
+  mkdirSync(fakeSaDir, { recursive: true })
+  writeFileSync(join(fakeSaDir, 'token'), 'fake-sa-token')
+  const originalUrl = process.env.PLT_WORLD_SERVICE_URL
+  const originalAppId = process.env.PLT_WORLD_APP_ID
+  const originalSaPath = process.env.PLT_WORLD_SA_PATH
+  process.env.PLT_WORLD_SERVICE_URL = 'http://localhost:9999'
+  process.env.PLT_WORLD_SA_PATH = fakeSaDir
+  delete process.env.PLT_WORLD_APP_ID
+
+  try {
+    assert.throws(
+      () => createWorld(),
+      { message: 'World application ID is required in Kubernetes; set options.appId or PLT_WORLD_APP_ID' }
+    )
+    const world = createWorld({ appId: 'explicit-app' })
+    await world.close()
+  } finally {
+    if (originalUrl) process.env.PLT_WORLD_SERVICE_URL = originalUrl
+    else delete process.env.PLT_WORLD_SERVICE_URL
+    if (originalAppId) process.env.PLT_WORLD_APP_ID = originalAppId
+    else delete process.env.PLT_WORLD_APP_ID
+    if (originalSaPath) process.env.PLT_WORLD_SA_PATH = originalSaPath
+    else delete process.env.PLT_WORLD_SA_PATH
+    rmSync(fakeSaDir, { recursive: true, force: true })
+  }
+})
+
 test('defaults deploymentVersion to local', async () => {
   const originalUrl = process.env.PLT_WORLD_SERVICE_URL
   const originalVersion = process.env.PLT_WORLD_DEPLOYMENT_VERSION
@@ -170,7 +199,7 @@ test('refuses to enqueue while the version is unresolved (local) in K8s', async 
   ;(globalThis as any).platformatic = undefined // no shared context -> stays local
 
   try {
-    const world = createWorld()
+    const world = createWorld({ appId: 'k8s-app' })
     assert.equal(await world.getDeploymentId(), 'local')
     // Enqueuing is refused so the run is not pinned to 'local' (its messages would
     // never route to the ICC-registered real-version handlers). Caller retries.


### PR DESCRIPTION
## Summary

- Advertise Workflow spec 4 and add persistent run attributes with validated, idempotent `attr_set` events.
- Support resilient run creation while preserving spec 3 and SDK 4 compatibility.
- Preserve namespaced workflow and step queues across routing, replay, wake-up, and handler validation.
- Require an explicit World application ID in Kubernetes to prevent identity mismatches.
- Map deterministic validation errors to the SDK-compatible World error shape.
- Make the E2E runtime independent of the default health-probe port.

Assisted-By: OpenAI:GPT-5.6-Sol <openai/gpt-5.6-sol>
