### PR TITLE
fix: stop caching the rotating k8s service account token

### DIFF
--- a/packages/workflow/lib/auth/index.ts
+++ b/packages/workflow/lib/auth/index.ts
@@ -44,7 +44,7 @@ async function authPlugin (app: FastifyInstance, config: AuthConfig): Promise<vo
   }
 
   const validateK8s = config.k8s
-    ? createK8sTokenValidator(app.pg, config.k8s)
+    ? createK8sTokenValidator(app.pg, config.k8s, app.log)
     : null
 
   app.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {

--- a/packages/workflow/lib/auth/k8s-token.ts
+++ b/packages/workflow/lib/auth/k8s-token.ts
@@ -1,11 +1,18 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { request as undiciRequest, Agent } from 'undici'
 import type pg from 'pg'
+
+const K8S_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 
 interface K8sConfig {
   apiServer: string
   caCert?: string
   adminServiceAccount?: string
+  saTokenPath?: string
+}
+
+interface Logger {
+  warn: (obj: object, msg: string) => void
 }
 
 export interface K8sValidationResult {
@@ -21,7 +28,7 @@ interface CacheEntry {
 
 const EXPIRY_BUFFER = 30_000 // 30 seconds before actual expiry
 
-export function createK8sTokenValidator (pool: pg.Pool, config: K8sConfig) {
+export function createK8sTokenValidator (pool: pg.Pool, config: K8sConfig, logger?: Logger) {
   const cache = new Map<string, CacheEntry>()
 
   let dispatcher: Agent | undefined
@@ -36,13 +43,11 @@ export function createK8sTokenValidator (pool: pg.Pool, config: K8sConfig) {
     }
   }
 
-  // Read this pod's own SA token to authenticate with the K8s API server
-  let ownToken: string | undefined
-  try {
-    ownToken = readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf-8').trim()
-  } catch {
-    // Token not available
-  }
+  // This pod's own SA token authenticates the TokenReview call. It is read per
+  // call because the kubelet rotates it and a copy cached here would expire
+  // within a day, making every caller look unauthenticated.
+  const saTokenPath = config.saTokenPath || K8S_TOKEN_PATH
+  const inK8s = existsSync(saTokenPath)
 
   return async function validateK8sToken (token: string): Promise<K8sValidationResult | null> {
     // Check cache
@@ -59,8 +64,8 @@ export function createK8sTokenValidator (pool: pg.Pool, config: K8sConfig) {
     })
 
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    if (ownToken) {
-      headers.Authorization = `Bearer ${ownToken}`
+    if (inK8s) {
+      headers.Authorization = `Bearer ${readFileSync(saTokenPath, 'utf-8').trim()}`
     }
 
     const response = await undiciRequest(
@@ -74,7 +79,10 @@ export function createK8sTokenValidator (pool: pg.Pool, config: K8sConfig) {
     )
 
     if (response.statusCode >= 400) {
-      await response.body.dump()
+      // Our own credentials or connectivity failed, not the caller's. Log it so
+      // this is not silently reported to every caller as invalid credentials.
+      const body = await response.body.text()
+      logger?.warn({ statusCode: response.statusCode, body }, 'TokenReview request failed')
       return null
     }
 

--- a/packages/workflow/test/k8s-token.test.ts
+++ b/packages/workflow/test/k8s-token.test.ts
@@ -2,6 +2,9 @@ import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
 import { randomBytes } from 'node:crypto'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { setupTest, teardownTest, type TestContext } from './helper.ts'
 import { createK8sTokenValidator } from '../lib/auth/k8s-token.ts'
 
@@ -264,9 +267,54 @@ describe('k8s-token validator', () => {
     })
 
     await validate('test-token-for-header')
-    // In test env (no K8s), ownToken is undefined so no auth header
+    // No SA token file outside K8s, so no auth header is sent
     assert.equal(receivedAuthHeader, undefined)
 
     mockServer.close()
+  })
+
+  it('should send the rotated own SA token, not the one present at creation', async () => {
+    const saDir = join(tmpdir(), `wf-k8s-token-${process.pid}`)
+    mkdirSync(saDir, { recursive: true })
+    const saTokenPath = join(saDir, 'token')
+    writeFileSync(saTokenPath, 'own-token-one')
+
+    const seen: (string | undefined)[] = []
+    mockServer = createServer((req, res) => {
+      seen.push(req.headers.authorization as string | undefined)
+      req.on('data', () => {})
+      req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({
+          status: {
+            authenticated: true,
+            user: { username: 'system:serviceaccount:platformatic:platformatic' },
+          },
+        }))
+      })
+    })
+    await new Promise<void>((resolve) => { mockServer.listen(0, resolve) })
+    const addr = mockServer.address() as { port: number }
+    apiServer = `http://127.0.0.1:${addr.port}`
+
+    const validate = createK8sTokenValidator(ctx.app.pg, {
+      apiServer,
+      adminServiceAccount: 'platformatic:platformatic',
+      saTokenPath,
+    })
+
+    try {
+      await validate('caller-token-a')
+
+      // The kubelet rotates our own token on disk; it must be picked up.
+      writeFileSync(saTokenPath, 'own-token-two')
+      // A different caller token avoids the success cache.
+      await validate('caller-token-b')
+
+      assert.deepEqual(seen, ['Bearer own-token-one', 'Bearer own-token-two'])
+    } finally {
+      mockServer.close()
+      rmSync(saDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { getSharedContext } from '@platformatic/globals'
 import type { World } from '@workflow/world'
+import { saPath } from './lib/sa-path.ts'
 import { HttpClient } from './lib/client.ts'
 import type { ClientConfig } from './lib/client.ts'
 import { createStorage } from './lib/storage.ts'
@@ -70,11 +71,6 @@ async function versionFromSharedContext (): Promise<string | undefined> {
   } catch {
     return undefined
   }
-}
-
-function saPath (file: string): string {
-  const base = process.env.PLT_WORLD_SA_PATH || '/var/run/secrets/kubernetes.io/serviceaccount'
-  return `${base}/${file}`
 }
 
 function isRunningInK8s (): boolean {

--- a/packages/world/src/lib/client.ts
+++ b/packages/world/src/lib/client.ts
@@ -1,9 +1,8 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { Readable } from 'node:stream'
 import { Pool } from 'undici'
 import { encode } from 'cbor-x'
-
-const K8S_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+import { saPath } from './sa-path.ts'
 
 export interface ClientConfig {
   serviceUrl: string
@@ -56,24 +55,21 @@ function buildQuery (query?: QueryParams): string {
 export class HttpClient {
   #pool: Pool
   #baseUrl: string
-  #token: string | null
+  #inK8s: boolean
 
   constructor (config: ClientConfig) {
     this.#pool = new Pool(config.serviceUrl)
     this.#baseUrl = `/api/v1/apps/${config.appId}`
-    this.#token = null
-    try {
-      this.#token = readFileSync(K8S_TOKEN_PATH, 'utf8').trim()
-    } catch {
-      // Not running in K8s — single-tenant mode, no auth needed
-    }
+    // No token file means single-tenant mode, where no auth is sent.
+    this.#inK8s = existsSync(saPath('token'))
   }
 
   #authHeaders (): Record<string, string> {
-    if (this.#token) {
-      return { authorization: `Bearer ${this.#token}` }
-    }
-    return {}
+    if (!this.#inK8s) return {}
+    // Read per request: the kubelet rotates this token, so a copy cached at
+    // construction expires within a day and the service then rejects it.
+    const token = readFileSync(saPath('token'), 'utf8').trim()
+    return { authorization: `Bearer ${token}` }
   }
 
   #path (path: string, query?: QueryParams): string {

--- a/packages/world/src/lib/sa-path.ts
+++ b/packages/world/src/lib/sa-path.ts
@@ -1,0 +1,5 @@
+// Location of the mounted Kubernetes service account, overridable for testing.
+export function saPath (file: string): string {
+  const base = process.env.PLT_WORLD_SA_PATH || '/var/run/secrets/kubernetes.io/serviceaccount'
+  return `${base}/${file}`
+}

--- a/packages/world/test/client-auth.test.ts
+++ b/packages/world/test/client-auth.test.ts
@@ -1,0 +1,73 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { HttpClient } from '../src/lib/client.ts'
+
+test('sends the rotated service account token, not the one present at construction', async () => {
+  const fakeSaDir = join(tmpdir(), `plt-world-client-auth-${process.pid}`)
+  mkdirSync(fakeSaDir, { recursive: true })
+  writeFileSync(join(fakeSaDir, 'token'), 'token-one')
+
+  const seen: (string | undefined)[] = []
+  const server = createServer((req, res) => {
+    seen.push(req.headers.authorization)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ ok: true }))
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as { port: number }
+
+  const originalSaPath = process.env.PLT_WORLD_SA_PATH
+  process.env.PLT_WORLD_SA_PATH = fakeSaDir
+
+  const client = new HttpClient({ serviceUrl: `http://127.0.0.1:${port}`, appId: 'demo' })
+
+  try {
+    await client.get('/runs')
+
+    // The kubelet rotates the token on disk; the client must pick it up.
+    writeFileSync(join(fakeSaDir, 'token'), 'token-two')
+    await client.get('/runs')
+
+    assert.deepEqual(seen, ['Bearer token-one', 'Bearer token-two'])
+  } finally {
+    await client.close()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+    if (originalSaPath) process.env.PLT_WORLD_SA_PATH = originalSaPath
+    else delete process.env.PLT_WORLD_SA_PATH
+    rmSync(fakeSaDir, { recursive: true, force: true })
+  }
+})
+
+test('sends no authorization header outside Kubernetes', async () => {
+  const emptyDir = join(tmpdir(), `plt-world-client-noauth-${process.pid}`)
+  mkdirSync(emptyDir, { recursive: true })
+
+  const seen: (string | undefined)[] = []
+  const server = createServer((req, res) => {
+    seen.push(req.headers.authorization)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ ok: true }))
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as { port: number }
+
+  const originalSaPath = process.env.PLT_WORLD_SA_PATH
+  process.env.PLT_WORLD_SA_PATH = emptyDir
+
+  const client = new HttpClient({ serviceUrl: `http://127.0.0.1:${port}`, appId: 'demo' })
+
+  try {
+    await client.get('/runs')
+    assert.deepEqual(seen, [undefined])
+  } finally {
+    await client.close()
+    await new Promise<void>(resolve => server.close(() => resolve()))
+    if (originalSaPath) process.env.PLT_WORLD_SA_PATH = originalSaPath
+    else delete process.env.PLT_WORLD_SA_PATH
+    rmSync(emptyDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Both the world client and the workflow service cached the pod's Kubernetes service account token in memory: the client in the `HttpClient` constructor, the service in the closure returned by `createK8sTokenValidator`. The kubelet rotates that token on disk and it expires within a day, so any pod running longer than the token lifetime kept presenting an expired credential.

For the client this meant the app could no longer call the workflow service, and triggering a run failed with `401 invalid credentials`. For the service it was worse: the cached token is what authenticates its own TokenReview calls to the Kubernetes API server, so once it expired the API server rejected those calls and every caller was reported as unauthenticated regardless of how valid their own token was.

Both now read the token at call time. Presence of the token file still decides Kubernetes mode once, since that genuinely does not change at runtime.

A failed TokenReview also discarded the API server's response body, which meant an expired token of our own was reported to callers as their credentials being invalid. It is now logged, so the two cases are distinguishable.

