### PR TITLE
feat(world): default the world application ID instead of requiring it

### DIFF
--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -105,11 +105,21 @@ export function createWorld (options?: Partial<CreateWorldOptions>): World {
   }
 
   const runningInK8s = isRunningInK8s()
-  const explicitAppId = options?.appId || process.env.PLT_WORLD_APP_ID
-  if (runningInK8s && !explicitAppId) {
-    throw new Error('World application ID is required in Kubernetes; set options.appId or PLT_WORLD_APP_ID')
-  }
+  // PLT_APP_NAME is the platform's own name for the application (watt-extra
+  // resolves it the same way), so it is preferred over the package name.
+  const explicitAppId = options?.appId ||
+    process.env.PLT_WORLD_APP_ID ||
+    process.env.PLT_APP_NAME
   const appId = explicitAppId || readAppName()
+  if (runningInK8s && !explicitAppId) {
+    // The package name is not guaranteed unique -- a Next.js app is often just
+    // "next" -- and where apps share a service account the binding check cannot
+    // catch a wrong claim. Say which ID was assumed rather than failing.
+    console.warn(
+      `[@platformatic/world] no application ID configured; assuming "${appId}" from package.json. ` +
+      'Set PLT_WORLD_APP_ID if this is not the application registered with the workflow service.'
+    )
+  }
   const explicitVersion = options?.deploymentVersion ||
     process.env.PLT_WORLD_DEPLOYMENT_VERSION ||
     process.env.PLT_DEPLOYMENT_VERSION

--- a/packages/world/test/world.test.ts
+++ b/packages/world/test/world.test.ts
@@ -64,25 +64,46 @@ test('reads from env vars', async () => {
   }
 })
 
-test('requires an explicit application ID in Kubernetes', async () => {
+test('falls back to the package name in Kubernetes, warning which ID it assumed', async () => {
   const fakeSaDir = join(tmpdir(), `plt-world-app-id-test-${process.pid}`)
   mkdirSync(fakeSaDir, { recursive: true })
   writeFileSync(join(fakeSaDir, 'token'), 'fake-sa-token')
   const originalUrl = process.env.PLT_WORLD_SERVICE_URL
   const originalAppId = process.env.PLT_WORLD_APP_ID
   const originalSaPath = process.env.PLT_WORLD_SA_PATH
+  const originalAppName = process.env.PLT_APP_NAME
   process.env.PLT_WORLD_SERVICE_URL = 'http://localhost:9999'
   process.env.PLT_WORLD_SA_PATH = fakeSaDir
   delete process.env.PLT_WORLD_APP_ID
+  delete process.env.PLT_APP_NAME
+
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (msg: string) => { warnings.push(String(msg)) }
 
   try {
-    assert.throws(
-      () => createWorld(),
-      { message: 'World application ID is required in Kubernetes; set options.appId or PLT_WORLD_APP_ID' }
-    )
-    const world = createWorld({ appId: 'explicit-app' })
-    await world.close()
+    // No explicit ID: supported, but the assumed ID must be announced.
+    const fallback = createWorld()
+    await fallback.close()
+    assert.equal(warnings.length, 1)
+    assert.match(warnings[0], /no application ID configured/)
+    assert.match(warnings[0], /PLT_WORLD_APP_ID/)
+
+    // An explicit ID is silent.
+    warnings.length = 0
+    const explicit = createWorld({ appId: 'explicit-app' })
+    await explicit.close()
+    assert.deepEqual(warnings, [])
+
+    // PLT_APP_NAME counts as configured, so it must not warn either.
+    process.env.PLT_APP_NAME = 'from-platform'
+    const viaAppName = createWorld()
+    await viaAppName.close()
+    assert.deepEqual(warnings, [])
   } finally {
+    console.warn = originalWarn
+    if (originalAppName) process.env.PLT_APP_NAME = originalAppName
+    else delete process.env.PLT_APP_NAME
     if (originalUrl) process.env.PLT_WORLD_SERVICE_URL = originalUrl
     else delete process.env.PLT_WORLD_SERVICE_URL
     if (originalAppId) process.env.PLT_WORLD_APP_ID = originalAppId


### PR DESCRIPTION
Deploying a workflow app anywhere other than the ICC deploy API required hand-setting `PLT_WORLD_APP_ID`, because only `deployment-builder.js` injects it. In observe mode ICC never templates the workload, and desk never injects the variable at all, so `createWorld` threw at startup with `World application ID is required in Kubernetes`.

The application ID is the app's own identity rather than something ICC has to mint, so it now falls back instead of failing: `options.appId`, then `PLT_WORLD_APP_ID`, then `PLT_APP_NAME`, then the package name. `PLT_APP_NAME` is included because watt-extra already resolves the application name that way, so the default gets more accurate for free if the platform ever sets it.

This restores the pre-0.10.0 behaviour that `1f79c01` replaced with a hard error, but keeps the diagnostic that was missing before: the same silent misconfiguration is now visible in the logs.
