### PR TITLE
fix(queue): reclaim stuck deliveries instead of reaping idle runs

### DIFF
--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -3,9 +3,18 @@ import createLeaderElector from '@platformatic/leader'
 import { decode, encode } from 'cbor-x'
 import { routeMessage } from './router.ts'
 import { dispatchMessage, type DispatchResult } from './dispatcher.ts'
-import { getRetryDelay, isMaxAttempts } from './retry.ts'
+import { getRetryDelay, isMaxAttempts, MAX_ATTEMPTS } from './retry.ts'
 
-const ORPHAN_CHECK_INTERVAL = 60_000
+// How often delivered-but-unacknowledged messages are reclaimed.
+const RECLAIM_CHECK_INTERVAL = 60_000
+// How long a message may stay 'delivered' before it is assumed its executor
+// died and it is redelivered. This bounds a single step, not a whole run: a
+// run may idle for days on a hook without any message outstanding, and that is
+// not a fault. Must exceed the slowest legitimate step (model calls included).
+const DEFAULT_VISIBILITY_TIMEOUT_S = 900
+const VISIBILITY_TIMEOUT_S = Number(process.env.WF_DELIVERY_VISIBILITY_TIMEOUT_S) > 0
+  ? Number(process.env.WF_DELIVERY_VISIBILITY_TIMEOUT_S)
+  : DEFAULT_VISIBILITY_TIMEOUT_S
 // Safety-net poll interval: scheduleNextWakeup() is fire-and-forget to avoid
 // blocking pendingNotify re-runs. When multiple executeOnce() cycles run
 // back-to-back, two concurrent scheduleNextWakeup() calls can race — the
@@ -216,10 +225,89 @@ async function lockRunForFailureFinalization (client: pg.PoolClient, msg: any): 
   )
 }
 
+// A message stuck in 'delivered' means its executor never reported back, most
+// likely because it died mid-step. Nothing else reclaims it: the retry paths
+// only touch 'pending', 'deferred' and 'failed'. Redelivering resumes the run
+// rather than failing it.
+//
+// Deliberately scoped to messages, not runs. A run with no message outstanding
+// is idle, not stuck -- it may be parked on a hook for days -- and inactivity
+// is not a fault in a durable workflow.
+export async function reclaimExpiredDeliveries (
+  client: pg.PoolClient,
+  log: any,
+  visibilityTimeoutS: number = VISIBILITY_TIMEOUT_S
+): Promise<number> {
+  try {
+    // Under the retry ceiling: hand it back to the poller for another attempt.
+    const reclaimed = await client.query(
+      `UPDATE workflow_queue_messages m
+       SET status = 'pending', attempts = m.attempts + 1,
+           delivered_at = NULL, updated_at = NOW()
+       FROM workflow_runs r
+       WHERE m.run_id = r.id
+         AND m.status = 'delivered'
+         AND m.delivered_at < NOW() - make_interval(secs => $1)
+         AND r.status IN ('pending', 'running')
+         AND m.attempts < $2
+       RETURNING m.id, m.run_id, m.queue_name, m.attempts`,
+      [visibilityTimeoutS, MAX_ATTEMPTS]
+    )
+
+    if (reclaimed.rows.length > 0) {
+      log.warn(
+        { count: reclaimed.rows.length, visibilityTimeoutS },
+        'Reclaimed delivered messages whose executor never reported back'
+      )
+    }
+
+    // At the ceiling there is nothing left to retry, so finalize rather than
+    // leave the run running forever.
+    const exhausted = await client.query(
+      `SELECT m.id, m.run_id, m.application_id, m.queue_name, m.deployment_version, m.attempts
+       FROM workflow_queue_messages m
+       JOIN workflow_runs r ON r.id = m.run_id
+       WHERE m.status = 'delivered'
+         AND m.delivered_at < NOW() - make_interval(secs => $1)
+         AND r.status IN ('pending', 'running')
+         AND m.attempts >= $2
+       LIMIT 10`,
+      [visibilityTimeoutS, MAX_ATTEMPTS]
+    )
+
+    for (const msg of exhausted.rows) {
+      await client.query('BEGIN')
+      try {
+        const failure = failureDetail(
+          msg, msg.attempts, 'DELIVERY_TIMEOUT',
+          `Message delivered but never acknowledged within ${visibilityTimeoutS}s, and retries are exhausted`
+        )
+        await lockRunForFailureFinalization(client, msg)
+        await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'dead', last_failure = $3, dead_at = NOW(),
+               failure_finalized_at = NOW(), updated_at = NOW()
+           WHERE id = $1 AND application_id = $2 AND status = 'delivered'`,
+          [msg.id, msg.application_id, failure]
+        )
+        await failRun(client, msg, failure)
+        await client.query('COMMIT')
+      } catch (err) {
+        await client.query('ROLLBACK')
+        throw err
+      }
+    }
+    return reclaimed.rows.length
+  } catch (err) {
+    log.error({ err }, 'Delivery reclaim error')
+    return 0
+  }
+}
+
 export function createPoller (pool: pg.Pool, connectionString: string, log: any) {
   let stopped = false
   let deferredTimer: ReturnType<typeof setTimeout> | null = null
-  let orphanTimer: ReturnType<typeof setInterval> | null = null
+  let reclaimTimer: ReturnType<typeof setInterval> | null = null
   let safetyTimer: ReturnType<typeof setInterval> | null = null
   let listenClient: pg.Client | null = null
   let executing = false
@@ -248,7 +336,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
   function startPolling (): void {
     stopped = false
     setupListener()
-    orphanTimer = setInterval(checkOrphans, ORPHAN_CHECK_INTERVAL)
+    reclaimTimer = setInterval(runReclaim, RECLAIM_CHECK_INTERVAL)
     safetyTimer = setInterval(() => execute(), SAFETY_POLL_INTERVAL)
     execute()
   }
@@ -256,7 +344,7 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
   function stopPolling (): void {
     stopped = true
     if (deferredTimer) { clearTimeout(deferredTimer); deferredTimer = null }
-    if (orphanTimer) { clearInterval(orphanTimer); orphanTimer = null }
+    if (reclaimTimer) { clearInterval(reclaimTimer); reclaimTimer = null }
     if (safetyTimer) { clearInterval(safetyTimer); safetyTimer = null }
     teardownListener()
   }
@@ -417,44 +505,14 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
     }
   }
 
-  async function checkOrphans (): Promise<void> {
+  async function runReclaim (): Promise<void> {
     if (stopped) return
-
     const client = await pool.connect()
     try {
-      const orphans = await client.query(
-        `SELECT id, application_id, deployment_id FROM workflow_runs
-         WHERE status = 'running'
-           AND updated_at < NOW() - INTERVAL '15 minutes'
-           AND id NOT IN (
-             SELECT DISTINCT run_id FROM workflow_queue_messages
-             WHERE status IN ('pending', 'deferred', 'failed')
-           )
-         LIMIT 10`
-      )
-
-      for (const orphan of orphans.rows) {
-        await client.query('BEGIN')
-        try {
-          await client.query(
-            'SELECT id FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
-            [orphan.id, orphan.application_id]
-          )
-          const msg = {
-            run_id: orphan.id,
-            application_id: orphan.application_id,
-            queue_name: '__wkf_workflow_orphaned',
-            deployment_version: orphan.deployment_id,
-          }
-          await failRun(client, msg, failureDetail(msg, 0, 'ORPHANED', 'Run orphaned: no activity for 15 minutes'))
-          await client.query('COMMIT')
-        } catch (err) {
-          await client.query('ROLLBACK')
-          throw err
-        }
-      }
+      const reclaimed = await reclaimExpiredDeliveries(client, log)
+      if (reclaimed > 0) execute()
     } catch (err) {
-      log.error({ err }, 'Orphan check error')
+      log.error({ err }, 'Delivery reclaim error')
     } finally {
       client.release()
     }

--- a/packages/workflow/test/delivery-reclaim.test.ts
+++ b/packages/workflow/test/delivery-reclaim.test.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from 'node:crypto'
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { reclaimExpiredDeliveries } from '../queue/poller.ts'
+import { setupTest, teardownTest, type TestContext } from './helper.ts'
+
+const silentLog = { warn () {}, error () {}, info () {} }
+
+describe('delivery reclaim', () => {
+  let ctx: TestContext
+  let applicationId: number
+
+  before(async () => {
+    ctx = await setupTest()
+    const app = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1',
+      [ctx.appId]
+    )
+    applicationId = app.rows[0].id
+  })
+
+  after(async () => {
+    await teardownTest(ctx)
+  })
+
+  async function makeRun (status = 'running'): Promise<string> {
+    const runId = `wrun_${randomUUID()}`
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status)
+       VALUES ($1, $2, 'wf', 'v1', $3)`,
+      [runId, applicationId, status]
+    )
+    return runId
+  }
+
+  async function makeMessage (runId: string, opts: { deliveredSecondsAgo?: number, status?: string, attempts?: number } = {}) {
+    const { deliveredSecondsAgo, status = 'delivered', attempts = 0 } = opts
+    const res = await ctx.app.pg.query(
+      `INSERT INTO workflow_queue_messages
+         (queue_name, run_id, deployment_version, application_id, payload, status, attempts, delivered_at)
+       VALUES ('__wkf_workflow_wf', $1, 'v1', $2, '{}'::jsonb, $3, $4,
+               CASE WHEN $5::int IS NULL THEN NULL ELSE NOW() - make_interval(secs => $5::int) END)
+       RETURNING id`,
+      [runId, applicationId, status, attempts, deliveredSecondsAgo ?? null]
+    )
+    return res.rows[0].id
+  }
+
+  async function withClient<T> (fn: (c: any) => Promise<T>): Promise<T> {
+    const client = await ctx.app.pg.connect()
+    try {
+      return await fn(client)
+    } finally {
+      client.release()
+    }
+  }
+
+  it('leaves an idle run alone: waiting on a hook is not a fault', async () => {
+    // The regression. The run is 'running' with nothing outstanding, exactly
+    // like an eve session parked between turns.
+    const runId = await makeRun()
+    await ctx.app.pg.query(
+      'UPDATE workflow_runs SET updated_at = NOW() - INTERVAL \'2 hours\' WHERE id = $1',
+      [runId]
+    )
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_hooks (id, run_id, application_id, token, correlation_id, status)
+       VALUES ($1, $2, $3, $4, $5, 'pending')`,
+      [randomUUID(), runId, applicationId, `${runId}:turn-control:0`, randomUUID()]
+    )
+
+    const reclaimed = await withClient(c => reclaimExpiredDeliveries(c, silentLog, 60))
+    assert.equal(reclaimed, 0)
+
+    const run = await ctx.app.pg.query('SELECT status FROM workflow_runs WHERE id = $1', [runId])
+    assert.equal(run.rows[0].status, 'running', 'an idle run must not be failed')
+  })
+
+  it('redelivers a message whose executor never reported back', async () => {
+    const runId = await makeRun()
+    const msgId = await makeMessage(runId, { deliveredSecondsAgo: 3600, attempts: 1 })
+
+    const reclaimed = await withClient(c => reclaimExpiredDeliveries(c, silentLog, 60))
+    assert.equal(reclaimed, 1)
+
+    const msg = await ctx.app.pg.query(
+      'SELECT status, attempts, delivered_at FROM workflow_queue_messages WHERE id = $1',
+      [msgId]
+    )
+    assert.equal(msg.rows[0].status, 'pending', 'must go back for another attempt')
+    assert.equal(msg.rows[0].attempts, 2, 'redelivery counts as an attempt')
+    assert.equal(msg.rows[0].delivered_at, null)
+
+    const run = await ctx.app.pg.query('SELECT status FROM workflow_runs WHERE id = $1', [runId])
+    assert.equal(run.rows[0].status, 'running', 'the run resumes rather than failing')
+  })
+
+  it('does not touch a delivery that is still within the timeout', async () => {
+    const runId = await makeRun()
+    const msgId = await makeMessage(runId, { deliveredSecondsAgo: 10 })
+
+    const reclaimed = await withClient(c => reclaimExpiredDeliveries(c, silentLog, 600))
+    assert.equal(reclaimed, 0)
+
+    const msg = await ctx.app.pg.query('SELECT status FROM workflow_queue_messages WHERE id = $1', [msgId])
+    assert.equal(msg.rows[0].status, 'delivered')
+  })
+
+  it('fails the run once redelivery attempts are exhausted', async () => {
+    const runId = await makeRun()
+    const msgId = await makeMessage(runId, { deliveredSecondsAgo: 3600, attempts: 10 })
+
+    await withClient(c => reclaimExpiredDeliveries(c, silentLog, 60))
+
+    const msg = await ctx.app.pg.query('SELECT status FROM workflow_queue_messages WHERE id = $1', [msgId])
+    assert.equal(msg.rows[0].status, 'dead', 'nothing left to retry')
+
+    const run = await ctx.app.pg.query('SELECT status, error FROM workflow_runs WHERE id = $1', [runId])
+    assert.equal(run.rows[0].status, 'failed')
+    assert.match(run.rows[0].error.toString('utf8'), /DELIVERY_TIMEOUT/)
+  })
+
+  it('ignores messages whose run already reached a terminal state', async () => {
+    const runId = await makeRun('completed')
+    const msgId = await makeMessage(runId, { deliveredSecondsAgo: 3600 })
+
+    const reclaimed = await withClient(c => reclaimExpiredDeliveries(c, silentLog, 60))
+    assert.equal(reclaimed, 0)
+
+    const msg = await ctx.app.pg.query('SELECT status FROM workflow_queue_messages WHERE id = $1', [msgId])
+    assert.equal(msg.rows[0].status, 'delivered')
+  })
+})


### PR DESCRIPTION
Orphan detection failed healthy runs. A run parked on a hook has no undelivered queue message and a frozen `updated_at`, so it matched every condition of the sweep: `status = 'running'`, stale, and nothing in `('pending','deferred','failed')`. An eve chat session waiting for its next turn was killed after fifteen minutes with `QueueDeliveryError / ORPHANED`, having done nothing wrong. The same applies to any long wait, including the `longRunning` workflow in `workflow-demo` whose stated purpose is to wait indefinitely on a hook.

It was guarding something real, though. A message that reaches `delivered` is never reclaimed, because the retry paths only touch `pending`, `deferred` and `failed`, so an executor dying mid-step stranded both the message and the run forever. Orphan detection was the only backstop, and "running, stale, nothing outstanding" was its proxy for "nobody is coming back". The proxy cannot tell a dead executor from a run that is legitimately idle, which is why it misfires.

That is a queue problem, so this addresses it as one. A delivery outstanding past a visibility timeout returns to `pending` with `attempts + 1` and is redelivered under the existing ceiling, so a transient executor loss resumes the run instead of failing it. At the ceiling the message is marked `dead` and the run is failed through the existing failure helpers, so nothing hangs. Being scoped to messages, it cannot misfire on an idle run: an idle run has no delivered-and-unacknowledged message, however long it waits.
