### PR TITLE
fix: hook not found

### DIFF
--- a/packages/world/src/lib/storage.ts
+++ b/packages/world/src/lib/storage.ts
@@ -155,13 +155,35 @@ export function createStorage (client: HttpClient) {
 
     hooks: {
       get: async (hookId: string, params?: any) => {
-        const result = await client.get(`/hooks/${hookId}`, buildQuery(params))
-        return restoreEntity(result)
+        try {
+          const result = await client.get(`/hooks/${hookId}`, buildQuery(params))
+          return restoreEntity(result)
+        } catch (err: any) {
+          if (err?.statusCode === 404) {
+            err.name = 'HookNotFoundError'
+            err.hookId = hookId
+          }
+          throw err
+        }
       },
 
       getByToken: async (token: string, params?: any) => {
-        const result = await client.get(`/hooks/by-token/${token}`, buildQuery(params))
-        return restoreEntity(result)
+        try {
+          const result = await client.get(`/hooks/by-token/${token}`, buildQuery(params))
+          return restoreEntity(result)
+        } catch (err: any) {
+          // A missing hook is normal control flow, not a transport failure:
+          // resuming a hook is how callers ask "does this session exist yet?".
+          // HookNotFoundError.is() checks error.name === 'HookNotFoundError',
+          // so without this name the miss is indistinguishable from a real
+          // outage and callers turn a routine "no session yet" into a hard
+          // failure instead of creating one.
+          if (err?.statusCode === 404) {
+            err.name = 'HookNotFoundError'
+            err.token = token
+          }
+          throw err
+        }
       },
 
       list: async (params: any) => {

--- a/packages/world/test/hook-not-found.test.ts
+++ b/packages/world/test/hook-not-found.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer, type Server } from 'node:http'
+import { once } from 'node:events'
+import { createPlatformaticWorld } from '../src/index.ts'
+
+// Hermetic: a stub service that always 404s the hook lookups, so the error
+// contract can be asserted without PostgreSQL or a running workflow service.
+describe('hooks not-found error naming', () => {
+  let server: Server
+  let world: ReturnType<typeof createPlatformaticWorld>
+
+  before(async () => {
+    server = createServer((req, res) => {
+      res.writeHead(404, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        statusCode: 404,
+        error: `Hook ${req.url} not found`,
+        message: `Hook ${req.url} not found`,
+      }))
+    })
+    server.listen(0)
+    await once(server, 'listening')
+    const { port } = server.address() as { port: number }
+
+    world = createPlatformaticWorld({
+      serviceUrl: `http://127.0.0.1:${port}`,
+      appId: 'default',
+      deploymentVersion: 'v1.0.0',
+    })
+  })
+
+  after(async () => {
+    if (world) await world.close()
+    server.close()
+    await once(server, 'close')
+  })
+
+  it('names a getByToken 404 so HookNotFoundError.is() matches', async () => {
+    const token = 'eve:eve:7caf22f2-f714-4493-8329-f5cd68a7f52e'
+    const err: any = await world.hooks.getByToken(token).then(
+      () => null,
+      (e: unknown) => e
+    )
+
+    assert.ok(err, 'expected getByToken to reject')
+    // HookNotFoundError.is() is a structural check on this exact name.
+    assert.equal(err.name, 'HookNotFoundError')
+    assert.equal(err.token, token)
+    assert.equal(err.statusCode, 404)
+  })
+
+  it('names a hooks.get 404 the same way', async () => {
+    const err: any = await world.hooks.get('hook_123').then(
+      () => null,
+      (e: unknown) => e
+    )
+
+    assert.ok(err, 'expected get to reject')
+    assert.equal(err.name, 'HookNotFoundError')
+    assert.equal(err.hookId, 'hook_123')
+    assert.equal(err.statusCode, 404)
+  })
+})


### PR DESCRIPTION
`hooks.getByToken` and `hooks.get` returned a bare `Error` on HTTP 404, so the workflow SDK could not recognize a hook miss. Both now tag the error with `name = 'HookNotFoundError'`.

