### PR TITLE
e2e: update workflow to 5.0.0-beta.39, drop experimental_setAttributes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
     ports:
       - '127.0.0.1:5434:5432'
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # postgres:18 stores data in a version subdirectory and expects the mount
+      # at /var/lib/postgresql (not /var/lib/postgresql/data, which it now treats
+      # as an unused legacy path and refuses to start against).
+      - pgdata:/var/lib/postgresql
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U wf -d workflow']
       interval: 2s

--- a/e2e-v5/package.json
+++ b/e2e-v5/package.json
@@ -11,11 +11,11 @@
   },
   "dependencies": {
     "@platformatic/world": "workspace:*",
-    "@workflow/world": "5.0.0-beta.23",
+    "@workflow/world": "5.0.0-beta.24",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "workflow": "5.0.0-beta.36"
+    "workflow": "5.0.0-beta.39"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/e2e-v5/workflows/greet.ts
+++ b/e2e-v5/workflows/greet.ts
@@ -1,4 +1,4 @@
-import { experimental_setAttributes as setAttributes } from 'workflow'
+import { setAttributes } from 'workflow'
 
 export async function greet (name: string) {
   'use workflow'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/world
       '@workflow/world':
-        specifier: 5.0.0-beta.23
-        version: 5.0.0-beta.23
+        specifier: 5.0.0-beta.24
+        version: 5.0.0-beta.24
       next:
         specifier: ^16.0.0
         version: 16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -67,8 +67,8 @@ importers:
         specifier: ^19.0.0
         version: 19.2.8(react@19.2.8)
       workflow:
-        specifier: 5.0.0-beta.36
-        version: 5.0.0-beta.36(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)(ws@8.21.1)
+        specifier: 5.0.0-beta.39
+        version: 5.0.0-beta.39(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)(ws@8.21.1)
     devDependencies:
       '@types/node':
         specifier: ^24.0.0
@@ -184,6 +184,9 @@ packages:
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-web-identity@3.972.49':
     resolution: {integrity: sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==}
@@ -1608,21 +1611,21 @@ packages:
   '@workflow/astro@4.0.13':
     resolution: {integrity: sha512-H1+uF4CKM8xLAGVoQSAVANlf9TT8MIdIUGCSuj/7x3s2cCGHbNtPSKGQXn6FHRT5hH5DDhpgbcMtEN1PsVu3IQ==}
 
-  '@workflow/astro@5.0.0-beta.36':
-    resolution: {integrity: sha512-ti5ONGcSGpyY5owvC17mJXAy9+mF75hdLxTj4mdBA0vRlxgqiJXODsVHwZIaKRugpim/F3b+4R6NjiSr5vXVuw==}
+  '@workflow/astro@5.0.0-beta.39':
+    resolution: {integrity: sha512-Cz8A3u23dLL5uktKoDSHxR5NTRq+UIHv+/5RZQu96SWMlfzAxo1RaAXVk7M7jRNtCd7gRu+zHZqyplPsiumpRg==}
 
   '@workflow/builders@4.1.3':
     resolution: {integrity: sha512-UCQkOXmVEx9a69ZOjO+5X5tibXkoPNkRaK+veDvAOPP513N/PeGcQZ/XU+qKfTk3aahzJrMEGRWVqeDvy5ItUw==}
 
-  '@workflow/builders@5.0.0-beta.36':
-    resolution: {integrity: sha512-ZhA6DVH/cBH9bP3XrnTUEcr6uzTKK3J/VkeHo7LpJ5R75Z9ZZ4LB3IdQdt4We+9ucF5XPMJHAqV2fwQclWCp1w==}
+  '@workflow/builders@5.0.0-beta.39':
+    resolution: {integrity: sha512-vmkFgHBTjyqH9z2RpZ0x3yJtUM030GbrA3FW7A1wiJYVnYGvnSV27r9XuPu4mCSwbzcEMkF1sGHpdqa3zDrhLA==}
 
   '@workflow/cli@4.3.2':
     resolution: {integrity: sha512-IrlnIoGUWo6Lz2sYv0IbUrlyrcpr9tjVTMK7a0gQzkVU9RIOXnQTkrVcnNpuCe6g30Pfz2ao8s1EWTiczkzylg==}
     hasBin: true
 
-  '@workflow/cli@5.0.0-beta.36':
-    resolution: {integrity: sha512-teG6472SfavrfkUslufCp8HbWlttB5NH41ftTQk5gEDHIwOK8AvkqwC9AdHzI25ppO8EED3gPf7rRC/ZMF6Whw==}
+  '@workflow/cli@5.0.0-beta.39':
+    resolution: {integrity: sha512-2ttD+XKfs+dJg+WFS7OAp9wxmp44JssstF53bq5rpa9ezCJks7kXRSRpoWQGxyHNVhRKiRb55Fk5vuwbkfYjTw==}
     hasBin: true
 
   '@workflow/core@4.6.2':
@@ -1633,8 +1636,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/core@5.0.0-beta.36':
-    resolution: {integrity: sha512-3SYp5PporQ7in7WKBwfQfjCvdV0aOk2gx3eM0jKXv5oNqlS1aQEUaT+sBlCZ3xhpgZ+RUZLAtAMvJHVFLkTSoQ==}
+  '@workflow/core@5.0.0-beta.39':
+    resolution: {integrity: sha512-fjm5DpH5O+FTor164GcfYGsVLb5ib9Ixlj65TM3+lZaiNFqo5+EyZIWolY8xc5mb4X4r5cC/x3/UDls8JVVm6g==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -1644,8 +1647,8 @@ packages:
   '@workflow/errors@4.1.5':
     resolution: {integrity: sha512-2v059f6EE0pi2xTZ9iU0KhNv5RErds3/z9ZmQ8JuEg8ThEYcKopbCrs5ZZ+lGtkOiPXTDaM0lCsimRHnfGwcZw==}
 
-  '@workflow/errors@5.0.0-beta.12':
-    resolution: {integrity: sha512-tyTEpKb4VoNR8d9WG6gDTGBDdmtuacSKAipzgOfRNQ9WNSzKjtWnp8nIXrvw5BnsfQ/hLsC00x1Q8Hbe8ojTMA==}
+  '@workflow/errors@5.0.0-beta.15':
+    resolution: {integrity: sha512-dLZRBPHEXJdK33y6SPMwcaMpEysvtCnE8kfmm4QKaGQIRMPHDh6KnCbxUwvN37MjOPrVtkpm09WxnJYEWrFOmA==}
 
   '@workflow/nest@4.0.14':
     resolution: {integrity: sha512-dd1l9L1qFZ00OJTs/TNbeW7WodWkpPZQutvHim0k0pOW8fUBK39SY8gcoxlsuJuune6s77tYLFgYI6Os6HCyhw==}
@@ -1656,8 +1659,8 @@ packages:
       '@swc/cli': '>=0.4.0'
       '@swc/core': '>=1.5.0'
 
-  '@workflow/nest@5.0.0-beta.36':
-    resolution: {integrity: sha512-6ZTeugEwBilnUs8VzTpqs4ZjqJB949dQHDd8k52xcILQixB2O5ggHpxfg/3wlvMaqBolDUQt06c6i+DcwiusIg==}
+  '@workflow/nest@5.0.0-beta.39':
+    resolution: {integrity: sha512-D3OyVeuCwysVeFQAvKGzbZ2T6e6UWS+h25mMy6YztJiawR/Atx8NLxSK6X09Dl6ppwhplcgMkeI0BbOnjR9dtg==}
     hasBin: true
     peerDependencies:
       '@nestjs/common': '>=10.0.0'
@@ -1673,8 +1676,8 @@ packages:
       next:
         optional: true
 
-  '@workflow/next@5.0.0-beta.36':
-    resolution: {integrity: sha512-qj9siVZHYfpsDpFRKQ2Qs/i7CCd6I+BTQgQUs4eUiWuVrkaj0nDo0ffMx876iGGCiUEpyrMaJLkbKWVW3P6Y2A==}
+  '@workflow/next@5.0.0-beta.39':
+    resolution: {integrity: sha512-HnIVZO4Cs4FnjfLguCmEgwlTk8EDy+i5zRXdp9c8u8uMpOvhH7ik1KT8PvMB44ZOUQF6IRrzAWi0CLYBu0sU8g==}
     peerDependencies:
       next: '>13'
     peerDependenciesMeta:
@@ -1684,20 +1687,20 @@ packages:
   '@workflow/nitro@4.1.4':
     resolution: {integrity: sha512-YSVMs/O0wml5MjzUitpER/20Z48Vy+uw4z2fi+2d3O/eqoOSQCjYkXTVF61C3WZJKCmwznuC802ZePlMoUqVHA==}
 
-  '@workflow/nitro@5.0.0-beta.36':
-    resolution: {integrity: sha512-KcXyvt8c/eqeqN+f+ZwYCtW9iADV2aLxHfPSyZxSJrMtviOkdqleyXkEAMJRv0TvSzAjOByh6K/nkIkPVgvgZw==}
+  '@workflow/nitro@5.0.0-beta.39':
+    resolution: {integrity: sha512-ooAzQe2Tx4JwKRgVGrQTRSt8lDjHrwLEi+tBrwjp01aui/3ziIHjrHhggI07lG72qvG7modgDHzVMiCyz/f0Ow==}
 
   '@workflow/nuxt@4.0.14':
     resolution: {integrity: sha512-/jHqKqgpyWtPBjxkyrRdDh0jqjnYJDCJfqOrEVef66a7sH+dWBo/HZ9/GNqVH7cYhqD+9Gn04oQPPg5gcUKT3Q==}
 
-  '@workflow/nuxt@5.0.0-beta.36':
-    resolution: {integrity: sha512-fOl+a1PbaG74ZFQwnHE4HkfOK7sihJnagwachIJ8XW6cT8DQKWG7h0WToK6Zok639OOs4RpKisdRcvg1l2gIDw==}
+  '@workflow/nuxt@5.0.0-beta.39':
+    resolution: {integrity: sha512-jZHwnuZ75cxiZGgDPwAG1h+arqL0PS7U/p/Mqos41D2e9Spqn+r3FpTajMLHs3JgC1m1f6BGyUBcXTKhtCpWfQ==}
 
   '@workflow/rollup@4.0.13':
     resolution: {integrity: sha512-d1nb1hOiITua/fyTORhifTqr/RLjXLyd/er3nLzydEpvYyZKRHI3RSVOvRDX5y3cPkpIdxci805yOtzYPCcH2w==}
 
-  '@workflow/rollup@5.0.0-beta.36':
-    resolution: {integrity: sha512-Ef3fv5MZBg7w0TUwX7PSx1hFSQp/VGPLldmud+lf8pCQl6xD/5JOfSFqb0MVDUKQ987e2tA5RcoWyDZqJEJQCQ==}
+  '@workflow/rollup@5.0.0-beta.39':
+    resolution: {integrity: sha512-cjopZHsI/r8vET0f3jR1MTGWFk158B6ISgsKazOmBtzlsxIaFmS7Vn0W2B5plqvfW/yLqDBKXD/PkgYS2Pc/nA==}
 
   '@workflow/serde@4.1.2':
     resolution: {integrity: sha512-KkkSUddEcaIvW7/QfVUk2PR93117HkDum45cXQEGkoxEmHOmqfOLJ4T1m4a1QABVC7O9TIqPxsBtDPgKIO+LOw==}
@@ -1708,8 +1711,8 @@ packages:
   '@workflow/sveltekit@4.0.13':
     resolution: {integrity: sha512-2MlS0TCD2E64sw2W+HPkVNr8W7GKGTeQPeeN0LOCWMGTa61D+kVErYqetw9y35buuR7g7/MWb2LcqUSlUdS+ig==}
 
-  '@workflow/sveltekit@5.0.0-beta.36':
-    resolution: {integrity: sha512-Nb8qetFMMUTYgWApiB7CKuGANB1N+t5CIS6dW4gLf4Fr/d1uJKDEqPyF0jtJJj6ZmhIV2juR9akeuc/MyEYvXA==}
+  '@workflow/sveltekit@5.0.0-beta.39':
+    resolution: {integrity: sha512-5ycx5UyCVZRD1l7RU05QVrmvbOfv+sYoVk4rYfohkGqB3zXKErReziGaNBDbNeMtXkUHhREVshYyo8uD1nKkVA==}
 
   '@workflow/swc-plugin@4.1.2':
     resolution: {integrity: sha512-oSd+fSXtcrHMJ82OwEqyfhYpqr1EsSQY5IEpntkKSlzzkdTFV4hcAj0vlafgIfI3WfhqxrXUoHfp/S1XE49jcA==}
@@ -1737,20 +1740,20 @@ packages:
   '@workflow/utils@4.1.4':
     resolution: {integrity: sha512-2zGTa0vCJJczErE8oI7JPKpGmXNbhgnGW7JWcz3qTTs5TKibtaAxha5DLq3WTTbwsgvuuxcnvtWqQ5hFxhWATg==}
 
-  '@workflow/utils@5.0.0-beta.6':
-    resolution: {integrity: sha512-YMZqvtRMzlmWkgshURp4ilvcY8VMrNxwXxDEXQ/gkppKWhJ1xdJBpq3plZLf8LWS7JHXd32Wqll/UvQeARu93Q==}
+  '@workflow/utils@5.0.0-beta.8':
+    resolution: {integrity: sha512-dDiQ/LT05g9HyOicqWNNX/Gw/fmO7Ma2kZ+ddUXXpm/EFTMRS9eiI69suSe1+1NnhMzdV6ObI8wrO5lvQqPIbg==}
 
   '@workflow/vite@4.0.13':
     resolution: {integrity: sha512-iJgQG8XRVIbDoGuYFvwnsXlN6Em5HK4pvas3TNMTOhgfILPrJV9LggmjvC18aXMGwDm+x9SwwuA5Es7SggRW0Q==}
 
-  '@workflow/vite@5.0.0-beta.36':
-    resolution: {integrity: sha512-1ilRlvRsSxgi0or9c9cr+57/F2Xf2/gX5nZ1PnLWZ3ra9haQYBeRxmawfcRB14RLmOIPDd55fWahN3a6qKZ+YA==}
+  '@workflow/vite@5.0.0-beta.39':
+    resolution: {integrity: sha512-eEGt3LF6LcQDxQ6ijClyj2OBIx8CqhDfHpIFop9EK8413PV6qHPSpbFzRLCRraBb4tnrTguN/Qbo6LkWFMPtBQ==}
 
   '@workflow/web@4.1.14':
     resolution: {integrity: sha512-CJtWaAw4bFTbP94gYxl03RX8xGgbybuTPwEzseOrk4vptTOIsY/vm8RiHEMiogMj60GUpq//kMApmRQOwYtPxg==}
 
-  '@workflow/web@5.0.0-beta.36':
-    resolution: {integrity: sha512-8gkSPMzwx3Jz+AxuFCuxu0ZDs0K5z5FSB60kXYFeZUTiPkncaq+Rxu+XdvjFQKErfGo5Kq67whBxe5gWu1c9qA==}
+  '@workflow/web@5.0.0-beta.39':
+    resolution: {integrity: sha512-gpUrR6Is/bSphioDg3+euS+8srP/pKvPgAgz+JVRmq4yAUtwZmuBDw2yrQCIyFa5KFKwdm4BjOP8E+Bp/1EPMQ==}
 
   '@workflow/world-local@4.2.2':
     resolution: {integrity: sha512-AvBgUUufC4Bv+XvK6qAmp2gEnNm7Au1iby6UuZNnp0tJJOZw0SzwymAHXqP9gepmSZqkp00bS7NuSHYqoQih7g==}
@@ -1760,8 +1763,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/world-local@5.0.0-beta.30':
-    resolution: {integrity: sha512-Cq06oJ2p8MXlTnV4GGTXUDhR4B6hjMIv7esUR6jecN8s0IktFpTab4FpKXEO9JYSjJ7elQlFGKzbghPdOkPFXQ==}
+  '@workflow/world-local@5.0.0-beta.33':
+    resolution: {integrity: sha512-78/rFCkhjO04azGEjUL0l8s2ou3P51SkN1XOhyyukR2wvlVIO36zdZB9DPuKQ5KEZkApS2+rwxspuzEVQnlmTw==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -1776,8 +1779,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/world-vercel@5.0.0-beta.32':
-    resolution: {integrity: sha512-ZS2/Mww7nf3IWiM9/qV1qEh9sXBaYU/ebL8P5MX8dgpP5uK/27fT14UukuljRpO6KfaPca503aXlEmuXAwmfwg==}
+  '@workflow/world-vercel@5.0.0-beta.35':
+    resolution: {integrity: sha512-pm1+SGmrEDPhJ4Un0Cns+zSWXlRVko25ubQcyeuZ+S1BFTi74YlKrFIb/IXwl0ug1NXq6Jw1QKAqXp726kweLg==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
@@ -1790,11 +1793,8 @@ packages:
   '@workflow/world@4.3.1':
     resolution: {integrity: sha512-gT67yCzMsm6SS5+2ho+b6dSd8qknTlDkfHvKnuWWt9fwkvpRr0WLWFOPvzILj3IY/mptDj3pFNDS9a6RWxEqQQ==}
 
-  '@workflow/world@5.0.0-beta.22':
-    resolution: {integrity: sha512-9m//a1EwMiOMhooHj0Y/yR8dM4bXgJfxlBo1yfcdYDmFUvrHLtqOjaZIdB94Zy5V19EiFJIslpWWivQJtAaU8w==}
-
-  '@workflow/world@5.0.0-beta.23':
-    resolution: {integrity: sha512-L7SwNa0fnxcZnu+7TTSbImBH6hvsV4EE2tBVdVv8fdAEqLKrLIFGsLcJuhuL//ZPr7emjLGqOwtFDc+fvrRlmA==}
+  '@workflow/world@5.0.0-beta.24':
+    resolution: {integrity: sha512-jt7KgonNywQgbq666vUrZyeqICL30+0mJc5u9qQzFTFnB7e9KLeehR3s1pnf/tr+SKTbaZh5lM6xUEYt14ib5g==}
 
   '@xhmikosr/archive-type@8.1.0':
     resolution: {integrity: sha512-EXOjEbnZFE5c/nFMf4FOrEURVanzHpnkPYmnmr78u02/8hAhE0FMq8p9TK1IM0/bFr5VcyBUY0gfLm8f7dKy+Q==}
@@ -2354,6 +2354,9 @@ packages:
 
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
+  devalue@5.9.0:
+    resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2940,6 +2943,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   ignore@7.0.6:
@@ -4552,8 +4559,8 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  workflow@5.0.0-beta.36:
-    resolution: {integrity: sha512-91Y7luEjcI2CPhoZLOCgDUCRUNM0bPdyFcTPvjxa0NFITBX8FZ75zpkEzUNNBSuf4DiuypOetmA0FI8g9RVx9Q==}
+  workflow@5.0.0-beta.39:
+    resolution: {integrity: sha512-qaoFlo/UT/95MUe/ULeFAfMrd4kIE1IlybBr6hy2AkodgUEWlnfeVDJ7gkUkSyE7DzQ9S6keHEp4vWZN68BUew==}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': '1'
@@ -6236,7 +6243,7 @@ snapshots:
     dependencies:
       async-listen: 3.0.0
       open: 8.4.0
-      xdg-app-paths: 5.1.0
+      xdg-app-paths: 5.5.1
       zod: 4.1.11
 
   '@vercel/cli-config@0.2.1':
@@ -6296,13 +6303,13 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/astro@5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/astro@5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/rollup': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/rollup': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
-      '@workflow/vite': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/vite': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       exsolve: 1.1.1
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -6331,15 +6338,13 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/builders@5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/builders@5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/core': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/errors': 5.0.0-beta.12
+      '@workflow/core': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/errors': 5.0.0-beta.15
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
-      '@workflow/utils': 5.0.0-beta.6
-      '@workflow/world-local': 5.0.0-beta.30(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 5.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@workflow/utils': 5.0.0-beta.8
       builtin-modules: 5.0.0
       chalk: 5.6.2
       enhanced-resolve: 5.19.0
@@ -6391,21 +6396,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/cli@5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/cli@5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/core': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/errors': 5.0.0-beta.12
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/core': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/errors': 5.0.0-beta.15
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
-      '@workflow/utils': 5.0.0-beta.6
-      '@workflow/web': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)
-      '@workflow/world': 5.0.0-beta.22
-      '@workflow/world-local': 5.0.0-beta.30(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 5.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@workflow/utils': 5.0.0-beta.8
+      '@workflow/web': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)
+      '@workflow/world': 5.0.0-beta.24
+      '@workflow/world-local': 5.0.0-beta.33(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 5.0.0-beta.35(@opentelemetry/api@1.9.1)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -6457,21 +6462,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/core@5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/core@5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
       '@standard-schema/spec': 1.0.0
       '@types/ms': 2.1.0
       '@vercel/functions': 3.7.6(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.1)
-      '@workflow/errors': 5.0.0-beta.12
+      '@workflow/errors': 5.0.0-beta.15
       '@workflow/serde': 5.0.0-beta.2
-      '@workflow/utils': 5.0.0-beta.6
-      '@workflow/world': 5.0.0-beta.22
-      '@workflow/world-local': 5.0.0-beta.30(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 5.0.0-beta.32(@opentelemetry/api@1.9.1)
+      '@workflow/utils': 5.0.0-beta.8
+      '@workflow/world': 5.0.0-beta.24
+      '@workflow/world-local': 5.0.0-beta.33(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 5.0.0-beta.35(@opentelemetry/api@1.9.1)
       debug: 4.4.3(supports-color@10.2.2)
-      devalue: 5.8.1
+      devalue: 5.9.0
       ms: 2.1.3
       nanoid: 5.1.6
       seedrandom: 3.0.5
@@ -6489,9 +6494,9 @@ snapshots:
       '@workflow/utils': 4.1.4
       ms: 2.1.3
 
-  '@workflow/errors@5.0.0-beta.12':
+  '@workflow/errors@5.0.0-beta.15':
     dependencies:
-      '@workflow/utils': 5.0.0-beta.6
+      '@workflow/utils': 5.0.0-beta.8
       ms: 2.1.3
 
   '@workflow/nest@4.0.14(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@8.1.1))(@swc/core@1.15.3)(supports-color@8.1.1)(ws@8.21.1)':
@@ -6509,13 +6514,13 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nest@5.0.0-beta.36(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/nest@5.0.0-beta.39(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@nestjs/common': 11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2)
       '@nestjs/core': 11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2)
       '@swc/core': 1.15.3
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
       esbuild: 0.28.1
       pathe: 2.0.3
@@ -6541,13 +6546,14 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/next@5.0.0-beta.36(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/next@5.0.0-beta.39(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/core': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/core': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
       chokidar: 4.0.3
+      ignore: 7.0.5
       semver: 7.7.4
     optionalDependencies:
       next: 16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -6574,15 +6580,15 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nitro@5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/nitro@5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/core': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/rollup': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/core': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/rollup': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
-      '@workflow/vite': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/web': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)
+      '@workflow/vite': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/web': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -6603,11 +6609,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/nuxt@5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/nuxt@5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@nuxt/kit': 4.4.8
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/nitro': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/nitro': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -6628,10 +6633,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/rollup@5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/rollup@5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
       exsolve: 1.0.7
     transitivePeerDependencies:
@@ -6660,13 +6665,13 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/sveltekit@5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/sveltekit@5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/rollup': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/rollup': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
-      '@workflow/vite': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/vite': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       exsolve: 1.1.1
       fs-extra: 11.4.0
       pathe: 2.0.3
@@ -6696,7 +6701,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  '@workflow/utils@5.0.0-beta.6':
+  '@workflow/utils@5.0.0-beta.8':
     dependencies:
       ms: 2.1.3
 
@@ -6709,9 +6714,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/vite@5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
+  '@workflow/vite@5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)':
     dependencies:
-      '@workflow/builders': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/builders': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -6724,9 +6729,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@workflow/web@5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)':
+  '@workflow/web@5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
-      '@workflow/world-local': 5.0.0-beta.30(@opentelemetry/api@1.9.1)
+      '@workflow/world-local': 5.0.0-beta.33(@opentelemetry/api@1.9.1)
       express: 5.2.1(supports-color@10.2.2)
       swr: 2.4.2(react@19.2.8)
     transitivePeerDependencies:
@@ -6747,12 +6752,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@workflow/world-local@5.0.0-beta.30(@opentelemetry/api@1.9.1)':
+  '@workflow/world-local@5.0.0-beta.33(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/queue': 0.4.0(@opentelemetry/api@1.9.1)
-      '@workflow/errors': 5.0.0-beta.12
-      '@workflow/utils': 5.0.0-beta.6
-      '@workflow/world': 5.0.0-beta.22
+      '@workflow/errors': 5.0.0-beta.15
+      '@workflow/utils': 5.0.0-beta.8
+      '@workflow/world': 5.0.0-beta.24
       async-sema: 3.1.1
       ulid: 3.0.2
       undici: 7.28.0
@@ -6772,12 +6777,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@workflow/world-vercel@5.0.0-beta.32(@opentelemetry/api@1.9.1)':
+  '@workflow/world-vercel@5.0.0-beta.35(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@vercel/queue': 0.4.0(@opentelemetry/api@1.9.1)
-      '@workflow/errors': 5.0.0-beta.12
-      '@workflow/world': 5.0.0-beta.22
+      '@workflow/errors': 5.0.0-beta.15
+      '@workflow/world': 5.0.0-beta.24
       cbor-x: 1.6.0
       ulid: 3.0.2
       undici: 7.28.0
@@ -6795,12 +6800,7 @@ snapshots:
       ulid: 3.0.2
       zod: 4.3.6
 
-  '@workflow/world@5.0.0-beta.22':
-    dependencies:
-      ulid: 3.0.2
-      zod: 4.3.6
-
-  '@workflow/world@5.0.0-beta.23':
+  '@workflow/world@5.0.0-beta.24':
     dependencies:
       ulid: 3.0.2
       zod: 4.3.6
@@ -7515,6 +7515,8 @@ snapshots:
     optional: true
 
   devalue@5.8.1: {}
+
+  devalue@5.9.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -8376,6 +8378,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   ignore@7.0.6: {}
 
@@ -10163,20 +10167,20 @@ snapshots:
       - typescript
       - ws
 
-  workflow@5.0.0-beta.36(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)(ws@8.21.1):
+  workflow@5.0.0-beta.39(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)(ws@8.21.1):
     dependencies:
-      '@workflow/astro': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/cli': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/core': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/errors': 5.0.0-beta.12
-      '@workflow/nest': 5.0.0-beta.36(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/next': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/nitro': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/nuxt': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/rollup': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
-      '@workflow/sveltekit': 5.0.0-beta.36(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/astro': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/cli': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/core': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/errors': 5.0.0-beta.15
+      '@workflow/nest': 5.0.0-beta.39(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(@nestjs/core@11.1.28(@nestjs/common@11.1.28(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@10.2.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)(supports-color@10.2.2))(@swc/core@1.15.3)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/next': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(next@16.2.12(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/nitro': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/nuxt': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(react@19.2.8)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/rollup': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
+      '@workflow/sveltekit': 5.0.0-beta.39(@opentelemetry/api@1.9.1)(supports-color@10.2.2)(ws@8.21.1)
       '@workflow/typescript-plugin': 5.0.0-beta.5(typescript@6.0.3)
-      '@workflow/utils': 5.0.0-beta.6
+      '@workflow/utils': 5.0.0-beta.8
       ms: 2.1.3
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
Supersedes #139 (Renovate's `workflow` → `5.0.0-beta.39` bump), which fails to build: `e2e-v5/workflows/greet.ts` imports `experimental_setAttributes`, and beta.39 removed it. The SDK renamed `experimental_setAttributes` → `setAttributes` in beta.31 (keeping a deprecated alias) and dropped the alias in beta.39, so `next build` (esbuild) can't resolve the import and the e2e job's build step fails — `lint` and `test` pass because they don't build the Next app.

This adopts the canonical `setAttributes` name (exported by both beta.36 and beta.39, so it builds before and after the bump) and moves `e2e-v5` to `workflow@5.0.0-beta.39` with `@workflow/world@5.0.0-beta.24` (the version `@workflow/core@5.0.0-beta.39` pins). The v4 line and `packages/world` are untouched.

Also fixes local dev Postgres, which the earlier `postgres:18` image bump broke: postgres:18 stores data in a version subdirectory and refuses to start against a volume mounted at `/var/lib/postgresql/data`, so the mount moves to `/var/lib/postgresql`. Local-dev only — CI uses a volume-less service container and is unaffected.

Verified locally against beta.39: e2e-v5 build passes, e2e-v5 smoke 5/5, e2e-v5 Vercel compat 61/61, e2e-v4 9/9, unit suites 37/132/8 pass, lint clean.
