### PR TITLE
world: add spec 7 sealed log compatibility

### DIFF
--- a/e2e-v5/package.json
+++ b/e2e-v5/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@platformatic/world": "workspace:*",
-    "@workflow/world": "5.0.0-beta.27",
+    "@workflow/world": "5.0.0-beta.29",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/workflow/test/events.test.ts
+++ b/packages/workflow/test/events.test.ts
@@ -843,10 +843,6 @@ describe('sealed log (spec 7)', () => {
   }
 
   it('allocates slot event ids for spec-7 runs', async () => {
-    // Spec 7 keeps slot identity; the slot trigger gates on spec_version >= 6,
-    // so a spec-7 run gets the same dense allocation as a spec-6 one. Allocating
-    // at the commit that fills the slot is what makes this log a gap-free prefix
-    // — and therefore spec-7 conformant with nothing to seal.
     const created = await createRun(7, 'sealed-log-slot-test')
     assert.equal(created.event.eventId, slotId(1))
     assert.equal(created.run.specVersion, 7)
@@ -866,10 +862,7 @@ describe('sealed log (spec 7)', () => {
   })
 
   it('reads back a noop event without choking on the unknown type', async () => {
-    // Our backend never writes a noop (it allocates at commit, so it has no
-    // abandoned slots to seal), but a run created by another World can carry
-    // one. The read path must pass it through so the runtime can skip it during
-    // replay rather than fail to parse it.
+    // Simulate a noop written by another backend.
     const created = await createRun(7, 'noop-read-test')
     const runId = created.run.runId
     const appRow = await ctx.app.pg.query('SELECT application_id FROM workflow_runs WHERE id = $1', [runId])
@@ -885,8 +878,6 @@ describe('sealed log (spec 7)', () => {
       headers: headers(),
     })).body)
     assert.deepEqual(list.data.map((e: any) => e.eventType), ['run_created', 'noop'])
-    // The noop takes a real slot, so the log stays dense and the reader's
-    // density check still sees a contiguous prefix.
     assert.deepEqual(list.data.map((e: any) => e.eventId), [slotId(1), slotId(2)])
     assert.deepEqual(list.data[1].eventData, { sealed: true })
   })

--- a/packages/workflow/test/events.test.ts
+++ b/packages/workflow/test/events.test.ts
@@ -812,3 +812,93 @@ describe('slot identity (spec 6)', () => {
     )
   })
 })
+
+describe('sealed log (spec 7)', () => {
+  let ctx: TestContext
+
+  before(async () => {
+    ctx = await setupTest()
+  })
+
+  after(async () => {
+    await teardownTest(ctx)
+  })
+
+  const headers = () => ({ authorization: `Bearer ${ctx.apiKey}` })
+  const slotId = (n: number) => 'evnt_' + String(n).padStart(26, '0')
+
+  async function createRun (specVersion: number, workflowName: string): Promise<any> {
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/null/events`,
+      headers: headers(),
+      payload: {
+        eventType: 'run_created',
+        specVersion,
+        eventData: { deploymentId: 'v1', workflowName, input: {} },
+      },
+    })
+    assert.equal(res.statusCode, 200)
+    return JSON.parse(res.body)
+  }
+
+  it('allocates slot event ids for spec-7 runs', async () => {
+    // Spec 7 keeps slot identity; the slot trigger gates on spec_version >= 6,
+    // so a spec-7 run gets the same dense allocation as a spec-6 one. Allocating
+    // at the commit that fills the slot is what makes this log a gap-free prefix
+    // — and therefore spec-7 conformant with nothing to seal.
+    const created = await createRun(7, 'sealed-log-slot-test')
+    assert.equal(created.event.eventId, slotId(1))
+    assert.equal(created.run.specVersion, 7)
+
+    const second = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${created.run.runId}/events`,
+      headers: headers(),
+      payload: {
+        eventType: 'attr_set',
+        correlationId: 'a',
+        specVersion: 7,
+        eventData: { changes: [{ key: 'k', value: 'v' }], writer: { type: 'workflow' } },
+      },
+    })
+    assert.equal(JSON.parse(second.body).event.eventId, slotId(2))
+  })
+
+  it('reads back a noop event without choking on the unknown type', async () => {
+    // Our backend never writes a noop (it allocates at commit, so it has no
+    // abandoned slots to seal), but a run created by another World can carry
+    // one. The read path must pass it through so the runtime can skip it during
+    // replay rather than fail to parse it.
+    const created = await createRun(7, 'noop-read-test')
+    const runId = created.run.runId
+    const appRow = await ctx.app.pg.query('SELECT application_id FROM workflow_runs WHERE id = $1', [runId])
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_events (run_id, application_id, event_type, event_data, spec_version)
+       VALUES ($1, $2, 'noop', $3, 7)`,
+      [runId, appRow.rows[0].application_id, Buffer.from(JSON.stringify({ sealed: true }))]
+    )
+
+    const list = JSON.parse((await ctx.app.inject({
+      method: 'GET',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events?sortOrder=asc`,
+      headers: headers(),
+    })).body)
+    assert.deepEqual(list.data.map((e: any) => e.eventType), ['run_created', 'noop'])
+    // The noop takes a real slot, so the log stays dense and the reader's
+    // density check still sees a contiguous prefix.
+    assert.deepEqual(list.data.map((e: any) => e.eventId), [slotId(1), slotId(2)])
+    assert.deepEqual(list.data[1].eventData, { sealed: true })
+  })
+
+  it('rejects a client-created noop (backend-only event type)', async () => {
+    const runId = (await createRun(7, 'noop-not-user-creatable')).run.runId
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/runs/${runId}/events`,
+      headers: headers(),
+      payload: { eventType: 'noop', specVersion: 7, eventData: { sealed: true } },
+    })
+    assert.equal(res.statusCode, 400)
+  })
+})

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -13,33 +13,16 @@ import { createEncryption } from './lib/encryption.ts'
 
 export interface PlatformaticWorldConfig extends ClientConfig, QueueConfig {}
 
-// Spec 6 (SLOT_IDENTITY) requires event ids to be slot-numbered
-// (`evnt_<26-digit slot>`): the runtime calls requireEventSlot on every event id
-// it loads and fails the run if it cannot parse a slot. The workflow service
-// emits those ids (migration 009).
+// Spec 6 requires slot-numbered event ids, provided by migration 009.
 const SPEC_VERSION_SUPPORTS_SLOT_IDENTITY = 6
-// Spec 7 (SEALED_LOG) is a *reader* contract: it says a reader understands that
-// a `noop` event may occupy a slot whose writer died, and skips it during replay
-// without advancing the deterministic clock. The obligation to seal such holes
-// falls only on a World that pre-assigns slot positions ahead of the commit that
-// fills them. Ours allocates each slot in the same transaction that occupies it
-// (migration 009's per-run advisory lock), so its log is a gap-free prefix by
-// construction: there is nothing to seal and it never emits a noop. That makes
-// it spec-7 compliant without a sequencer. The read path still tolerates `noop`
-// should one ever appear (e.g. a run created by another World).
+// Atomic slot allocation keeps the log dense, so spec 7 needs no noop writer.
+// The read path still passes through backend-created noop events.
 const SPEC_VERSION_SUPPORTS_SEALED_LOG = 7
 
-// Mirrors the SDK's mintedSpecVersion()/WORKFLOW_SEALED_LOG kill switch: opting
-// out stamps 6 instead of 7. Kept in lockstep so a rollback flips both halves.
-// Reimplemented rather than imported because @workflow/world is a type-only
-// devDep here (and pinned to the v4 line, which predates the helper), so the
-// published package must not gain a runtime dependency on it.
+// Reimplemented because the type-only @workflow/world dependency is pinned to v4.
 const warnedEnvValues = new Set<string>()
 
-// Matches the SDK's envFlag: unset/empty takes the fallback, 0/false and
-// 1/true are honoured, and anything else warns once before falling back. The
-// warning matters most during an emergency rollback — a typo'd
-// WORKFLOW_SEALED_LOG would otherwise silently keep the sealed log on.
+// Match the SDK flag semantics, including one warning per invalid value.
 function envFlag (name: string, fallback: boolean, env: NodeJS.ProcessEnv): boolean {
   const raw = env[name]
   if (raw === undefined || raw === '') return fallback

--- a/packages/world/src/index.ts
+++ b/packages/world/src/index.ts
@@ -13,18 +13,58 @@ import { createEncryption } from './lib/encryption.ts'
 
 export interface PlatformaticWorldConfig extends ClientConfig, QueueConfig {}
 
-// Declared capability ceiling. Spec 6 (SLOT_IDENTITY) requires event ids to be
-// slot-numbered (`evnt_<26-digit slot>`): the runtime calls requireEventSlot on
-// every event id it loads and fails the run if it cannot parse a slot. Unlike
-// spec 5 (gzip payloads, which storage carries opaquely) this is NOT inert — it
-// obliges the workflow service to emit slot-formatted event ids.
+// Spec 6 (SLOT_IDENTITY) requires event ids to be slot-numbered
+// (`evnt_<26-digit slot>`): the runtime calls requireEventSlot on every event id
+// it loads and fails the run if it cannot parse a slot. The workflow service
+// emits those ids (migration 009).
 const SPEC_VERSION_SUPPORTS_SLOT_IDENTITY = 6
+// Spec 7 (SEALED_LOG) is a *reader* contract: it says a reader understands that
+// a `noop` event may occupy a slot whose writer died, and skips it during replay
+// without advancing the deterministic clock. The obligation to seal such holes
+// falls only on a World that pre-assigns slot positions ahead of the commit that
+// fills them. Ours allocates each slot in the same transaction that occupies it
+// (migration 009's per-run advisory lock), so its log is a gap-free prefix by
+// construction: there is nothing to seal and it never emits a noop. That makes
+// it spec-7 compliant without a sequencer. The read path still tolerates `noop`
+// should one ever appear (e.g. a run created by another World).
+const SPEC_VERSION_SUPPORTS_SEALED_LOG = 7
+
+// Mirrors the SDK's mintedSpecVersion()/WORKFLOW_SEALED_LOG kill switch: opting
+// out stamps 6 instead of 7. Kept in lockstep so a rollback flips both halves.
+// Reimplemented rather than imported because @workflow/world is a type-only
+// devDep here (and pinned to the v4 line, which predates the helper), so the
+// published package must not gain a runtime dependency on it.
+const warnedEnvValues = new Set<string>()
+
+// Matches the SDK's envFlag: unset/empty takes the fallback, 0/false and
+// 1/true are honoured, and anything else warns once before falling back. The
+// warning matters most during an emergency rollback — a typo'd
+// WORKFLOW_SEALED_LOG would otherwise silently keep the sealed log on.
+function envFlag (name: string, fallback: boolean, env: NodeJS.ProcessEnv): boolean {
+  const raw = env[name]
+  if (raw === undefined || raw === '') return fallback
+  const normalized = raw.toLowerCase()
+  if (normalized === '0' || normalized === 'false') return false
+  if (normalized === '1' || normalized === 'true') return true
+  const key = `${name}=${raw}`
+  if (!warnedEnvValues.has(key)) {
+    warnedEnvValues.add(key)
+    console.warn(`[workflow] Ignoring ${name}: expected 0/1/true/false; using default ${fallback}`)
+  }
+  return fallback
+}
+
+function mintedSpecVersion (env: NodeJS.ProcessEnv = process.env): number {
+  return envFlag('WORKFLOW_SEALED_LOG', true, env)
+    ? SPEC_VERSION_SUPPORTS_SEALED_LOG
+    : SPEC_VERSION_SUPPORTS_SLOT_IDENTITY
+}
 
 export function createPlatformaticWorld (config: PlatformaticWorldConfig): World {
   const client = new HttpClient(config)
 
   return {
-    specVersion: SPEC_VERSION_SUPPORTS_SLOT_IDENTITY,
+    specVersion: mintedSpecVersion(),
     ...createStorage(client),
     ...createQueue(client, config),
     ...createStreamer(client),

--- a/packages/world/test/queue.test.ts
+++ b/packages/world/test/queue.test.ts
@@ -252,18 +252,71 @@ test('createQueueHandler accepts a health check for the alternate endpoint', asy
   await world.close!()
 })
 
-test('world declares specVersion 6 (slot identity)', () => {
+test('world declares specVersion 7 (sealed log)', () => {
   const world = createPlatformaticWorld({
     serviceUrl: 'http://localhost:9999',
     appId: 'app',
     deploymentVersion: 'v1',
   })
   assert.ok(world.specVersion > SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
-  // Literal, not SPEC_VERSION_SUPPORTS_SLOT_IDENTITY: this package's @workflow/world
+  // Literal, not SPEC_VERSION_SUPPORTS_SEALED_LOG: this package's @workflow/world
   // devDep is the v4 line, which doesn't export that constant, and it's a
   // type-only dep we don't want to turn into a runtime value import. This is the
   // world's declared capability ceiling — keep it pinned so a change is deliberate.
-  assert.equal(world.specVersion, 6)
+  assert.equal(world.specVersion, 7)
+})
+
+test('WORKFLOW_SEALED_LOG kill switch stamps specVersion 6', () => {
+  const previous = process.env.WORKFLOW_SEALED_LOG
+  const build = () => createPlatformaticWorld({
+    serviceUrl: 'http://localhost:9999',
+    appId: 'app',
+    deploymentVersion: 'v1',
+  }).specVersion
+  try {
+    for (const off of ['0', 'false', 'FALSE']) {
+      process.env.WORKFLOW_SEALED_LOG = off
+      assert.equal(build(), 6, `${off} should opt out of the sealed log`)
+    }
+    // Explicitly on, and unset/empty, keep the default silently.
+    for (const on of ['1', 'true', '']) {
+      process.env.WORKFLOW_SEALED_LOG = on
+      assert.equal(build(), 7, `${JSON.stringify(on)} should keep the sealed log`)
+    }
+    delete process.env.WORKFLOW_SEALED_LOG
+    assert.equal(build(), 7)
+  } finally {
+    if (previous === undefined) delete process.env.WORKFLOW_SEALED_LOG
+    else process.env.WORKFLOW_SEALED_LOG = previous
+  }
+})
+
+test('an unparseable WORKFLOW_SEALED_LOG warns once and keeps the default', () => {
+  // A typo during an emergency rollback must not silently leave the sealed log
+  // on: mirror the SDK's envFlag, which warns once per distinct bad value.
+  const previous = process.env.WORKFLOW_SEALED_LOG
+  const originalWarn = console.warn
+  const warnings: string[] = []
+  console.warn = (...args: unknown[]) => { warnings.push(args.join(' ')) }
+  try {
+    process.env.WORKFLOW_SEALED_LOG = 'nonsense'
+    const build = () => createPlatformaticWorld({
+      serviceUrl: 'http://localhost:9999',
+      appId: 'app',
+      deploymentVersion: 'v1',
+    }).specVersion
+    assert.equal(build(), 7)
+    assert.equal(warnings.length, 1)
+    assert.match(warnings[0], /WORKFLOW_SEALED_LOG/)
+    assert.match(warnings[0], /expected 0\/1\/true\/false/)
+    // Same bad value again: still just the one warning.
+    assert.equal(build(), 7)
+    assert.equal(warnings.length, 1)
+  } finally {
+    console.warn = originalWarn
+    if (previous === undefined) delete process.env.WORKFLOW_SEALED_LOG
+    else process.env.WORKFLOW_SEALED_LOG = previous
+  }
 })
 
 test('HTTP 400 errors are classified as WorkflowWorldError', async () => {

--- a/packages/world/test/queue.test.ts
+++ b/packages/world/test/queue.test.ts
@@ -259,10 +259,7 @@ test('world declares specVersion 7 (sealed log)', () => {
     deploymentVersion: 'v1',
   })
   assert.ok(world.specVersion > SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT)
-  // Literal, not SPEC_VERSION_SUPPORTS_SEALED_LOG: this package's @workflow/world
-  // devDep is the v4 line, which doesn't export that constant, and it's a
-  // type-only dep we don't want to turn into a runtime value import. This is the
-  // world's declared capability ceiling — keep it pinned so a change is deliberate.
+  // The v4 type-only dependency does not export the spec 7 constant.
   assert.equal(world.specVersion, 7)
 })
 
@@ -278,7 +275,6 @@ test('WORKFLOW_SEALED_LOG kill switch stamps specVersion 6', () => {
       process.env.WORKFLOW_SEALED_LOG = off
       assert.equal(build(), 6, `${off} should opt out of the sealed log`)
     }
-    // Explicitly on, and unset/empty, keep the default silently.
     for (const on of ['1', 'true', '']) {
       process.env.WORKFLOW_SEALED_LOG = on
       assert.equal(build(), 7, `${JSON.stringify(on)} should keep the sealed log`)
@@ -292,8 +288,6 @@ test('WORKFLOW_SEALED_LOG kill switch stamps specVersion 6', () => {
 })
 
 test('an unparseable WORKFLOW_SEALED_LOG warns once and keeps the default', () => {
-  // A typo during an emergency rollback must not silently leave the sealed log
-  // on: mirror the SDK's envFlag, which warns once per distinct bad value.
   const previous = process.env.WORKFLOW_SEALED_LOG
   const originalWarn = console.warn
   const warnings: string[] = []
@@ -309,7 +303,6 @@ test('an unparseable WORKFLOW_SEALED_LOG warns once and keeps the default', () =
     assert.equal(warnings.length, 1)
     assert.match(warnings[0], /WORKFLOW_SEALED_LOG/)
     assert.match(warnings[0], /expected 0\/1\/true\/false/)
-    // Same bad value again: still just the one warning.
     assert.equal(build(), 7)
     assert.equal(warnings.length, 1)
   } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/world
       '@workflow/world':
-        specifier: 5.0.0-beta.27
-        version: 5.0.0-beta.27
+        specifier: 5.0.0-beta.29
+        version: 5.0.0-beta.29
       next:
         specifier: ^16.0.0
         version: 16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1799,9 +1799,6 @@ packages:
 
   '@workflow/world@4.4.0':
     resolution: {integrity: sha512-rlq2qr0VFWG3YYqMpD9k95Tz5h5zqr24Bg8PheZ+rJgkgWZBXWLHS5BkiTA7K3l58NC8M78qkMGakU2/gb3Aag==}
-
-  '@workflow/world@5.0.0-beta.27':
-    resolution: {integrity: sha512-6+cpxAKgKuIO7khpTZFs9WVTTt8CVXWL8+QTz8VQJFtjg9QF1Kfc3bHPpzj1j6jjQCW6X0pF7CsQGSpLKuL9gw==}
 
   '@workflow/world@5.0.0-beta.29':
     resolution: {integrity: sha512-3z5GHEJgvb2AFfznQ4JfT1rm5U9jNupuG4YtrUUrtJ+807JkcjhP85fMN7Jo30975CcPPgnZmlnYI4sM0Y1d/w==}
@@ -6865,11 +6862,6 @@ snapshots:
       - utf-8-validate
 
   '@workflow/world@4.4.0':
-    dependencies:
-      ulid: 3.0.2
-      zod: 4.3.6
-
-  '@workflow/world@5.0.0-beta.27':
     dependencies:
       ulid: 3.0.2
       zod: 4.3.6


### PR DESCRIPTION
## Summary

Add spec 7 sealed-log compatibility to `@platformatic/world`. New worlds advertise spec 7 by default while `WORKFLOW_SEALED_LOG=0` or `false` retains spec 6 as an emergency fallback. Platformatic World allocates each event slot in the transaction that fills it, so its event log is already a dense prefix and does not need to emit `noop` events. The read path remains compatible with backend-created `noop` events and the write API rejects client-created ones.

Update the v5 E2E fixture to `@workflow/world@5.0.0-beta.29` and add coverage for spec 7 slot allocation, `noop` reads, the fallback flag, and invalid flag warnings.

## Tests

- `pnpm run lint`
- Spec 7 workflow and World tests added
