### PR TITLE
queue: align queue names and deployment signalling with the world spec

### DIFF
--- a/packages/workflow/plugins/queue.ts
+++ b/packages/workflow/plugins/queue.ts
@@ -38,6 +38,16 @@ async function queuePlugin (app: FastifyInstance): Promise<void> {
 
     await checkQueueRateLimit(app, appId)
 
+    if (envelope.idempotencyKey) {
+      const existing = await app.pg.query(
+        'SELECT id FROM workflow_queue_messages WHERE idempotency_key = $1',
+        [envelope.idempotencyKey]
+      )
+      if (existing.rows.length > 0) {
+        throw new DuplicateIdempotencyKey(envelope.idempotencyKey)
+      }
+    }
+
     // Fail fast when the target deployment version is expired. routeMessage()
     // already refuses to dispatch to an expired version, so accepting the
     // message here only buys it ten doomed delivery attempts before the poller
@@ -52,16 +62,6 @@ async function queuePlugin (app: FastifyInstance): Promise<void> {
         [appId, deploymentVersion]
       )
       if (version.rows[0]?.status === 'expired') throw new VersionExpired(deploymentVersion)
-    }
-
-    if (envelope.idempotencyKey) {
-      const existing = await app.pg.query(
-        'SELECT id FROM workflow_queue_messages WHERE idempotency_key = $1',
-        [envelope.idempotencyKey]
-      )
-      if (existing.rows.length > 0) {
-        throw new DuplicateIdempotencyKey(envelope.idempotencyKey)
-      }
     }
 
     // For cbor, we store the encoded message bytes so dispatch can forward

--- a/packages/workflow/plugins/queue.ts
+++ b/packages/workflow/plugins/queue.ts
@@ -1,7 +1,7 @@
 import fp from 'fastify-plugin'
 import type { FastifyInstance } from 'fastify'
 import { encode } from 'cbor-x'
-import { DuplicateIdempotencyKey, BadRequest } from '../lib/errors.ts'
+import { DuplicateIdempotencyKey, BadRequest, VersionExpired } from '../lib/errors.ts'
 import { checkQueueRateLimit } from '../lib/quotas.ts'
 import type { CborBody } from './cbor.ts'
 
@@ -33,10 +33,26 @@ async function queuePlugin (app: FastifyInstance): Promise<void> {
       throw new BadRequest('queueName and message are required')
     }
 
-    await checkQueueRateLimit(app, appId)
-
     const runId = envelope.message.runId || envelope.message.workflowRunId || ''
     const deploymentVersion = envelope.deploymentId || ''
+
+    await checkQueueRateLimit(app, appId)
+
+    // Fail fast when the target deployment version is expired. routeMessage()
+    // already refuses to dispatch to an expired version, so accepting the
+    // message here only buys it ten doomed delivery attempts before the poller
+    // dead-letters it. 410 is the spec's "this deployment cannot receive the
+    // message" signal, which the World client surfaces through
+    // isDeploymentUnavailableError() so the SDK can re-route instead of retry.
+    // Draining versions still accept work, matching routeMessage().
+    if (deploymentVersion) {
+      const version = await app.pg.query(
+        `SELECT status FROM workflow_deployment_versions
+         WHERE application_id = $1 AND deployment_version = $2`,
+        [appId, deploymentVersion]
+      )
+      if (version.rows[0]?.status === 'expired') throw new VersionExpired(deploymentVersion)
+    }
 
     if (envelope.idempotencyKey) {
       const existing = await app.pg.query(

--- a/packages/workflow/plugins/run-actions.ts
+++ b/packages/workflow/plugins/run-actions.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance } from 'fastify'
 
 const ulid = monotonicFactory()
 import { RunNotFound, BadRequest } from '../lib/errors.ts'
+import { workflowQueueName } from '../queue/names.ts'
 import { formatRun, encodeData } from './events.ts'
 
 async function runActionsPlugin (app: FastifyInstance): Promise<void> {
@@ -52,7 +53,7 @@ async function runActionsPlugin (app: FastifyInstance): Promise<void> {
          ORDER BY id ASC LIMIT 1`,
         [runId, appId]
       )
-      const queueName = originalQueue.rows[0]?.queue_name || `__wkf_workflow_${row.workflow_name}`
+      const queueName = originalQueue.rows[0]?.queue_name || workflowQueueName(row.workflow_name)
       await client.query(
         `INSERT INTO workflow_queue_messages
          (queue_name, run_id, deployment_version, application_id, payload, status)

--- a/packages/workflow/queue/names.ts
+++ b/packages/workflow/queue/names.ts
@@ -1,0 +1,54 @@
+// Queue-name grammar, mirroring @workflow/world's queue.ts.
+//
+// Restated rather than imported because this service does not depend on
+// @workflow/world (the same call made for slot identity in plugins/events.ts).
+// The patterns are copied from the spec so a namespaced deployment routes here
+// exactly as it does in the SDK.
+//
+// The spec supports an optional namespace between the sentinel and the kind:
+//
+//   __wkf_workflow_<id>              (default)
+//   __{namespace}_wkf_workflow_<id>  (WORKFLOW_QUEUE_NAMESPACE)
+//
+// Matching on the bare `__wkf_workflow_` literal silently misses the namespaced
+// form, which is how a namespaced workflow message ends up dispatched to the
+// webhook handler.
+
+// Spec: /^__(?:[a-z][a-z0-9]*_)?wkf_workflow_.+$/
+const WORKFLOW_QUEUE_RE = /^__(?:[a-z][a-z0-9]*_)?wkf_workflow_(.+)$/
+// v4 dispatched background steps on their own prefix; v5 folded them into the
+// workflow queue and dropped it. Still recognised so a v4 runtime keeps routing.
+const STEP_QUEUE_RE = /^__(?:[a-z][a-z0-9]*_)?wkf_step_(.+)$/
+// Everything up to and including the kind, e.g. `__acme_wkf_workflow_`.
+const QUEUE_PREFIX_RE = /^(__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_)/
+
+export function isWorkflowQueue (queueName: string): boolean {
+  return WORKFLOW_QUEUE_RE.test(queueName)
+}
+
+export function isStepQueue (queueName: string): boolean {
+  return STEP_QUEUE_RE.test(queueName)
+}
+
+// The workflow id carried in the queue name, namespace or not.
+export function workflowNameFromQueue (queueName: string): string | undefined {
+  return WORKFLOW_QUEUE_RE.exec(queueName)?.[1]
+}
+
+export function resolveQueueNamespace (namespace?: string): string | undefined {
+  return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined
+}
+
+export function workflowQueueName (workflowName: string, namespace?: string): string {
+  const ns = resolveQueueNamespace(namespace)
+  return ns ? `__${ns}_wkf_workflow_${workflowName}` : `__wkf_workflow_${workflowName}`
+}
+
+// A workflow queue name in the same namespace as `sourceQueueName`. Used when a
+// delivery spawns a follow-up message: the continuation belongs on the queue the
+// original arrived on, not on whatever this process's env happens to say.
+export function workflowQueueNameLike (sourceQueueName: string, workflowName: string): string {
+  const prefix = QUEUE_PREFIX_RE.exec(sourceQueueName)?.[1]
+  if (!prefix) return workflowQueueName(workflowName)
+  return `${prefix.replace(/wkf_step_$/, 'wkf_workflow_')}${workflowName}`
+}

--- a/packages/workflow/queue/names.ts
+++ b/packages/workflow/queue/names.ts
@@ -35,13 +35,27 @@ export function workflowNameFromQueue (queueName: string): string | undefined {
   return WORKFLOW_QUEUE_RE.exec(queueName)?.[1]
 }
 
+// Spec: /^[a-z][a-z0-9]*$/
+const QUEUE_NAMESPACE_RE = /^[a-z][a-z0-9]*$/
+
+// Mirrors the spec's resolveQueueNamespace: reads, does not validate.
 export function resolveQueueNamespace (namespace?: string): string | undefined {
   return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined
 }
 
 export function workflowQueueName (workflowName: string, namespace?: string): string {
   const ns = resolveQueueNamespace(namespace)
-  return ns ? `__${ns}_wkf_workflow_${workflowName}` : `__wkf_workflow_${workflowName}`
+  if (ns === undefined) return `__wkf_workflow_${workflowName}`
+  // Validate where the prefix is built, as the spec's getQueueTopicPrefix does.
+  // An unchecked namespace produces a name no matcher recognises, which routes
+  // to the webhook handler instead of the workflow one -- the exact silent
+  // misroute this module exists to prevent. Fail loudly on misconfiguration.
+  if (!QUEUE_NAMESPACE_RE.test(ns)) {
+    throw new Error(
+      `Invalid WORKFLOW_QUEUE_NAMESPACE ${JSON.stringify(ns)}: must be lowercase alphanumeric, starting with a letter`
+    )
+  }
+  return `__${ns}_wkf_workflow_${workflowName}`
 }
 
 // A workflow queue name in the same namespace as `sourceQueueName`. Used when a

--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -4,6 +4,7 @@ import { decode, encode } from 'cbor-x'
 import { routeMessage } from './router.ts'
 import { dispatchMessage, type DispatchResult } from './dispatcher.ts'
 import { getRetryDelay, isMaxAttempts, MAX_ATTEMPTS } from './retry.ts'
+import { isStepQueue, isWorkflowQueue, workflowNameFromQueue, workflowQueueNameLike } from './names.ts'
 
 // How often delivered-but-unacknowledged messages are reclaimed.
 const RECLAIM_CHECK_INTERVAL = 60_000
@@ -140,7 +141,7 @@ async function ensureRunForWorkflowDelivery (client: pg.PoolClient, msg: any): P
   const runInput = payload?.runInput
   const workflowName = typeof runInput?.workflowName === 'string'
     ? runInput.workflowName
-    : msg.queue_name.slice('__wkf_workflow_'.length)
+    : workflowNameFromQueue(msg.queue_name)
   const deploymentId = typeof runInput?.deploymentId === 'string'
     ? runInput.deploymentId
     : msg.deployment_version
@@ -198,7 +199,7 @@ async function failBackgroundStep (client: pg.PoolClient, msg: any, failure: Fai
        (queue_name, run_id, deployment_version, application_id,
         payload, payload_bytes, payload_encoding, status)
      VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
-    [`__wkf_workflow_${step.rows[0].workflow_name}`, msg.run_id, msg.deployment_version,
+    [workflowQueueNameLike(msg.queue_name, step.rows[0].workflow_name), msg.run_id, msg.deployment_version,
       msg.application_id, payloadJson, payloadBytes, msg.payload_encoding]
   )
   await client.query("SELECT pg_notify('deferred_messages', '{}')")
@@ -209,16 +210,16 @@ async function finalizeFailure (client: pg.PoolClient, msg: any, failure: Failur
   // v5 dispatches background steps through the workflow queue, while v4 uses
   // a dedicated step queue. The payload is the authoritative discriminator.
   if (await failBackgroundStep(client, msg, failure)) return
-  if (msg.queue_name.startsWith('__wkf_workflow_')) {
+  if (isWorkflowQueue(msg.queue_name)) {
     await failRun(client, msg, failure)
-  } else if (msg.queue_name.startsWith('__wkf_step_')) {
+  } else if (isStepQueue(msg.queue_name)) {
     await failRun(client, msg, failure)
   }
 }
 
 async function lockRunForFailureFinalization (client: pg.PoolClient, msg: any): Promise<void> {
   if (!msg.run_id) return
-  if (msg.queue_name.startsWith('__wkf_workflow_')) await ensureRunForWorkflowDelivery(client, msg)
+  if (isWorkflowQueue(msg.queue_name)) await ensureRunForWorkflowDelivery(client, msg)
   await client.query(
     'SELECT id FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
     [msg.run_id, msg.application_id]

--- a/packages/workflow/queue/router.ts
+++ b/packages/workflow/queue/router.ts
@@ -1,4 +1,5 @@
 import type pg from 'pg'
+import { isStepQueue, isWorkflowQueue } from './names.ts'
 
 export interface RouteResult {
   url: string
@@ -31,10 +32,11 @@ export async function routeMessage (
 
   if (registrations.rows.length === 0) return null
 
-  const queueMatch = queueName.match(/^__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_.+$/)
-  const urlField = queueMatch?.[1] === 'step'
+  // Same grammar as the rest of the service, from ./names.ts, so routing and
+  // failure finalization cannot drift apart on what counts as a workflow queue.
+  const urlField = isStepQueue(queueName)
     ? 'step_url'
-    : queueMatch?.[1] === 'workflow' ? 'workflow_url' : 'webhook_url'
+    : isWorkflowQueue(queueName) ? 'workflow_url' : 'webhook_url'
   const urls = [...new Set(registrations.rows.map(registration => registration[urlField]))]
   const url = urls[Math.floor(Math.random() * urls.length)]
 

--- a/packages/workflow/test/queue.test.ts
+++ b/packages/workflow/test/queue.test.ts
@@ -233,6 +233,25 @@ describe('spec alignment', () => {
     // A namespace must be lowercase alphanumeric starting with a letter.
     assert.ok(!isWorkflowQueue('__9bad_wkf_workflow_greet'))
 
+    // An invalid WORKFLOW_QUEUE_NAMESPACE must fail loudly where the prefix is
+    // built (as the spec's getQueueTopicPrefix does), not silently produce a
+    // name that routes to the webhook handler.
+    const { workflowQueueName } = await import('../queue/names.ts')
+    const previousNs = process.env.WORKFLOW_QUEUE_NAMESPACE
+    try {
+      process.env.WORKFLOW_QUEUE_NAMESPACE = 'acme'
+      assert.equal(workflowQueueName('greet'), '__acme_wkf_workflow_greet')
+      for (const bad of ['Bad_Name', '9lives', 'has-dash', 'UPPER']) {
+        process.env.WORKFLOW_QUEUE_NAMESPACE = bad
+        assert.throws(() => workflowQueueName('greet'), /WORKFLOW_QUEUE_NAMESPACE/)
+      }
+      delete process.env.WORKFLOW_QUEUE_NAMESPACE
+      assert.equal(workflowQueueName('greet'), '__wkf_workflow_greet')
+    } finally {
+      if (previousNs === undefined) delete process.env.WORKFLOW_QUEUE_NAMESPACE
+      else process.env.WORKFLOW_QUEUE_NAMESPACE = previousNs
+    }
+
     // A continuation stays in the namespace the original arrived on.
     assert.equal(workflowQueueNameLike('__acme_wkf_workflow_greet', 'other'), '__acme_wkf_workflow_other')
     assert.equal(workflowQueueNameLike('__acme_wkf_step_add', 'other'), '__acme_wkf_workflow_other')
@@ -281,5 +300,37 @@ describe('spec alignment', () => {
       },
     })
     assert.equal(draining.statusCode, 201)
+  })
+
+  it('still dedupes an already-accepted message after its version expires', async () => {
+    // A retry of a message we already enqueued must answer 409, which the SDK
+    // reads as successful deduplication. Answering 410 would tell it the
+    // delivery is terminally undeliverable and could fail a healthy run.
+    const appRow = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+    )
+    const key = `idem-${randomBytes(8).toString('hex')}`
+    const send = () => ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/queue`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        queueName: '__wkf_workflow_dedupe-after-expiry',
+        message: { runId: 'wrun_dedupe' },
+        deploymentId: 'v-dedupe',
+        idempotencyKey: key,
+      },
+    })
+
+    assert.equal((await send()).statusCode, 201)
+
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_deployment_versions (application_id, deployment_version, status)
+       VALUES ($1, 'v-dedupe', 'expired')
+       ON CONFLICT (application_id, deployment_version) DO UPDATE SET status = 'expired'`,
+      [appRow.rows[0].id]
+    )
+
+    assert.equal((await send()).statusCode, 409)
   })
 })

--- a/packages/workflow/test/queue.test.ts
+++ b/packages/workflow/test/queue.test.ts
@@ -211,3 +211,75 @@ describe('queue', () => {
     assert.equal(response.statusCode, 409)
   })
 })
+
+describe('spec alignment', () => {
+  let ctx: TestContext
+
+  before(async () => { ctx = await setupTest() })
+  after(async () => { await teardownTest(ctx) })
+
+  it('routes namespaced queue names by the spec grammar, not a bare prefix', async () => {
+    // The spec allows __{namespace}_wkf_workflow_<id> (WORKFLOW_QUEUE_NAMESPACE).
+    // Matching the un-namespaced literal sent these to the webhook handler.
+    const { isWorkflowQueue, isStepQueue, workflowNameFromQueue, workflowQueueNameLike } =
+      await import('../queue/names.ts')
+
+    assert.ok(isWorkflowQueue('__wkf_workflow_greet'))
+    assert.ok(isWorkflowQueue('__acme_wkf_workflow_greet'))
+    assert.equal(workflowNameFromQueue('__acme_wkf_workflow_greet'), 'greet')
+    assert.ok(isStepQueue('__acme_wkf_step_add'))
+    assert.ok(!isWorkflowQueue('__acme_wkf_step_add'))
+    assert.ok(!isWorkflowQueue('webhook'))
+    // A namespace must be lowercase alphanumeric starting with a letter.
+    assert.ok(!isWorkflowQueue('__9bad_wkf_workflow_greet'))
+
+    // A continuation stays in the namespace the original arrived on.
+    assert.equal(workflowQueueNameLike('__acme_wkf_workflow_greet', 'other'), '__acme_wkf_workflow_other')
+    assert.equal(workflowQueueNameLike('__acme_wkf_step_add', 'other'), '__acme_wkf_workflow_other')
+    assert.equal(workflowQueueNameLike('webhook', 'other'), '__wkf_workflow_other')
+  })
+
+  it('refuses to enqueue for an expired deployment version', async () => {
+    const appRow = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+    )
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_deployment_versions (application_id, deployment_version, status)
+       VALUES ($1, 'v-expired', 'expired')
+       ON CONFLICT (application_id, deployment_version) DO UPDATE SET status = 'expired'`,
+      [appRow.rows[0].id]
+    )
+
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/queue`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        queueName: '__wkf_workflow_expired-version',
+        message: { runId: 'wrun_expired' },
+        deploymentId: 'v-expired',
+      },
+    })
+    // 410 is what the World client reports through isDeploymentUnavailableError.
+    assert.equal(res.statusCode, 410)
+
+    // A draining version still accepts work, matching routeMessage().
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_deployment_versions (application_id, deployment_version, status)
+       VALUES ($1, 'v-draining', 'draining')
+       ON CONFLICT (application_id, deployment_version) DO UPDATE SET status = 'draining'`,
+      [appRow.rows[0].id]
+    )
+    const draining = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/queue`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        queueName: '__wkf_workflow_draining-version',
+        message: { runId: 'wrun_draining' },
+        deploymentId: 'v-draining',
+      },
+    })
+    assert.equal(draining.statusCode, 201)
+  })
+})

--- a/packages/world/src/lib/queue.ts
+++ b/packages/world/src/lib/queue.ts
@@ -118,5 +118,14 @@ export function createQueue (client: HttpClient, config: QueueConfig) {
     return config.deploymentVersion
   }
 
-  return { queue, createQueueHandler, getDeploymentId }
+  // Spec hook (@workflow/world Queue): true only when the error definitively
+  // means the targeted deployment cannot receive the message, so the SDK can
+  // re-route instead of retrying. The workflow service answers 410
+  // (WF_VERSION_EXPIRED) for exactly that case; every other status, including
+  // transport failures with no status at all, stays retryable.
+  const isDeploymentUnavailableError = (error: unknown): boolean => {
+    return (error as { statusCode?: number } | null)?.statusCode === 410
+  }
+
+  return { queue, createQueueHandler, getDeploymentId, isDeploymentUnavailableError }
 }


### PR DESCRIPTION
Align queue handling with the `@workflow/world` specification.

- Centralize queue-name parsing, including `WORKFLOW_QUEUE_NAMESPACE`.
- Preserve queue namespaces during retries, failure handling, and replay.
- Reject messages targeting expired deployment versions with 410 while continuing to accept draining versions.
- Implement `isDeploymentUnavailableError()` so the SDK can identify terminal deployment failures.

