### PR TITLE
queue: make the queue backend pluggable

### DIFF
--- a/packages/workflow/migrations/010.do.sql
+++ b/packages/workflow/migrations/010.do.sql
@@ -1,0 +1,50 @@
+-- Outbox marker for the queue's Postgres-to-broker handoff.
+--
+-- Postgres stays the source of truth for every queue message, whatever carries
+-- the bytes. With the default Postgres transport the row and its publication
+-- commit together, so published_at is stamped inline and the outbox is always
+-- empty. With a remote transport (Redis, SQS) the two cannot share a
+-- transaction: the message row commits first with published_at NULL, and a
+-- relay hands it to the broker and stamps published_at afterwards.
+--
+-- Committing before publishing is what makes the dual write safe. A crash
+-- before the publish leaves a row the relay picks up later; a crash between the
+-- publish and the stamp republishes, which is harmless because the consumer
+-- gate (claimForDispatch) refuses a message that is no longer dispatchable.
+--
+-- Existing rows are backfilled as published: they predate any remote transport,
+-- so they are by definition already where they need to be.
+-- No default, deliberately. NULL means "committed, not yet handed to the
+-- transport", and the relay runs for every transport including Postgres (where
+-- publishing is a no-op and the relay only stamps the column). That way a
+-- producer which writes a row directly -- run replay, a background-step
+-- continuation, draining -- is picked up automatically instead of being marked
+-- published without ever having been sent. Defaulting to NOW() would have made
+-- exactly those rows invisible to a remote broker, permanently.
+ALTER TABLE workflow_queue_messages ADD COLUMN published_at TIMESTAMPTZ;
+
+-- Which transport received it. published_at alone says a message was handed
+-- over, not who to, so switching WF_QUEUE_DRIVER would strand every in-flight
+-- row: already marked published, but never actually sent to the new broker.
+-- Recording the destination lets the relay notice the mismatch and republish,
+-- which makes a driver change self-healing instead of something that needs the
+-- queue drained first.
+ALTER TABLE workflow_queue_messages ADD COLUMN published_to VARCHAR;
+
+-- Existing rows were carried by the only transport that has ever existed.
+UPDATE workflow_queue_messages
+  SET published_at = COALESCE(created_at, NOW()), published_to = 'postgres';
+
+-- The relay's query: committed, ready, and not yet handed to the transport that
+-- is running now. Partial on status alone, since the published_to comparison is
+-- against a runtime value.
+CREATE INDEX idx_wqm_unpublished ON workflow_queue_messages (created_at)
+  WHERE status = 'pending';
+
+-- Terminal marker for a delivery the consumer completed.
+--
+-- claimForDispatch moves a message to 'delivered', and reclaimExpired treats a
+-- row still sitting there past the visibility timeout as an executor that died
+-- mid-step. A successful delivery therefore has to leave that state, or it gets
+-- redispatched against a run that is still legitimately running.
+ALTER TABLE workflow_queue_messages ADD COLUMN acked_at TIMESTAMPTZ;

--- a/packages/workflow/migrations/010.undo.sql
+++ b/packages/workflow/migrations/010.undo.sql
@@ -1,0 +1,4 @@
+ALTER TABLE workflow_queue_messages DROP COLUMN IF EXISTS published_to;
+ALTER TABLE workflow_queue_messages DROP COLUMN IF EXISTS acked_at;
+DROP INDEX IF EXISTS idx_wqm_unpublished;
+ALTER TABLE workflow_queue_messages DROP COLUMN IF EXISTS published_at;

--- a/packages/workflow/plugins/dead-letters.ts
+++ b/packages/workflow/plugins/dead-letters.ts
@@ -65,7 +65,11 @@ async function deadLettersPlugin (app: FastifyInstance): Promise<void> {
       const result = await client.query(
         `UPDATE workflow_queue_messages
          SET status = 'pending', attempts = 0, next_retry_at = NULL,
-             dead_at = NULL, updated_at = NOW()
+             dead_at = NULL, updated_at = NOW(),
+             -- Back into the outbox. The broker copy of this message was acked
+             -- when it died, so a row that still looks published would never be
+             -- handed to the transport again.
+             published_at = NULL, published_to = NULL
          WHERE id = $1 AND application_id = $2 AND status = 'dead'
            AND failure_finalized_at IS NULL
          RETURNING id`,

--- a/packages/workflow/plugins/poller.ts
+++ b/packages/workflow/plugins/poller.ts
@@ -1,11 +1,24 @@
 import fp from 'fastify-plugin'
 import type { FastifyInstance } from 'fastify'
 import { createPoller } from '../queue/poller.ts'
+import { createQueueBackend } from '../queue/factory.ts'
 
 async function pollerPlugin (app: FastifyInstance): Promise<void> {
-  if (process.env.WF_ENABLE_POLLER === 'false') return
+  const { driver, store, transport, makeCoordinator } =
+    createQueueBackend(app.pg, app.pgConnectionString, app.log)
+  app.log.info({ driver }, 'Queue transport selected')
 
-  const poller = createPoller(app.pg, app.pgConnectionString, app.log)
+  const poller = createPoller(store, transport, app.pg, app.log, makeCoordinator)
+
+  app.decorate('queueStore', store)
+
+  // WF_ENABLE_POLLER=false means this process must not drain the queue, but it
+  // may still enqueue, so the store is decorated either way.
+  if (process.env.WF_ENABLE_POLLER === 'false') {
+    app.addHook('onClose', async () => { await transport.close() })
+    return
+  }
+
   app.addHook('onReady', async () => { poller.start() })
   app.addHook('onClose', async () => { await poller.stop() })
 }

--- a/packages/workflow/plugins/queue.ts
+++ b/packages/workflow/plugins/queue.ts
@@ -38,6 +38,16 @@ async function queuePlugin (app: FastifyInstance): Promise<void> {
 
     await checkQueueRateLimit(app, appId)
 
+    if (envelope.idempotencyKey) {
+      const existing = await app.pg.query(
+        'SELECT id FROM workflow_queue_messages WHERE idempotency_key = $1',
+        [envelope.idempotencyKey]
+      )
+      if (existing.rows.length > 0) {
+        throw new DuplicateIdempotencyKey(envelope.idempotencyKey)
+      }
+    }
+
     // Fail fast when the target deployment version is expired. routeMessage()
     // already refuses to dispatch to an expired version, so accepting the
     // message here only buys it ten doomed delivery attempts before the poller
@@ -52,16 +62,6 @@ async function queuePlugin (app: FastifyInstance): Promise<void> {
         [appId, deploymentVersion]
       )
       if (version.rows[0]?.status === 'expired') throw new VersionExpired(deploymentVersion)
-    }
-
-    if (envelope.idempotencyKey) {
-      const existing = await app.pg.query(
-        'SELECT id FROM workflow_queue_messages WHERE idempotency_key = $1',
-        [envelope.idempotencyKey]
-      )
-      if (existing.rows.length > 0) {
-        throw new DuplicateIdempotencyKey(envelope.idempotencyKey)
-      }
     }
 
     // For cbor, we store the encoded message bytes so dispatch can forward

--- a/packages/workflow/plugins/queue.ts
+++ b/packages/workflow/plugins/queue.ts
@@ -71,58 +71,40 @@ async function queuePlugin (app: FastifyInstance): Promise<void> {
 
     const delaySeconds = envelope.delaySeconds || 0
 
+    // Through the store rather than a direct INSERT: it owns whether a message
+    // is publishable on commit or has to go through the outbox relay, and a
+    // second enqueue path here would silently bypass that for a remote
+    // transport. The HTTP concerns above (encoding, quota, dedupe, 410) stay
+    // here; only the write is the store's.
+    let messageId
+    try {
+      const enqueued = await app.queueStore.enqueue({
+        queueName: envelope.queueName,
+        applicationId: appId,
+        runId,
+        deploymentVersion,
+        payload: payloadJson,
+        payloadBytes,
+        payloadEncoding: encoding,
+        idempotencyKey: envelope.idempotencyKey || null,
+        delaySeconds,
+      })
+      messageId = enqueued.messageId
+    } catch (err: any) {
+      if (err.code === '23505') throw new DuplicateIdempotencyKey(envelope.idempotencyKey || '')
+      throw err
+    }
+
+    reply.code(201)
     if (delaySeconds > 0) {
-      let result
-      try {
-        result = await app.pg.query(
-          `INSERT INTO workflow_queue_messages
-           (idempotency_key, queue_name, run_id, deployment_version, application_id,
-            payload, payload_bytes, payload_encoding, status, deliver_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'deferred', NOW() + make_interval(secs => $9))
-           RETURNING id`,
-          [envelope.idempotencyKey || null, envelope.queueName, runId, deploymentVersion, appId,
-            payloadJson, payloadBytes, encoding, delaySeconds]
-        )
-      } catch (err: any) {
-        if (err.code === '23505') throw new DuplicateIdempotencyKey(envelope.idempotencyKey || '')
-        throw err
-      }
-
-      const messageId = result.rows[0].id
-
-      await app.pg.query("SELECT pg_notify('deferred_messages', '{}')")
-
-      reply.code(201)
       return {
         messageId: `msg_${messageId}`,
         scheduled: true,
         deliverAt: new Date(Date.now() + delaySeconds * 1000).toISOString(),
       }
     }
-
-    let insertResult
-    try {
-      insertResult = await app.pg.query(
-        `INSERT INTO workflow_queue_messages
-         (idempotency_key, queue_name, run_id, deployment_version, application_id,
-          payload, payload_bytes, payload_encoding, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending')
-         RETURNING id`,
-        [envelope.idempotencyKey || null, envelope.queueName, runId, deploymentVersion, appId,
-          payloadJson, payloadBytes, encoding]
-      )
-    } catch (err: any) {
-      if (err.code === '23505') throw new DuplicateIdempotencyKey(envelope.idempotencyKey || '')
-      throw err
-    }
-
-    const messageId = insertResult.rows[0].id
-
-    await app.pg.query("SELECT pg_notify('deferred_messages', '{}')")
-
-    reply.code(201)
     return { messageId: `msg_${messageId}` }
   })
 }
 
-export default fp(queuePlugin, { name: 'queue', dependencies: ['auth', 'cbor'] })
+export default fp(queuePlugin, { name: 'queue', dependencies: ['auth', 'cbor', 'poller'] })

--- a/packages/workflow/plugins/queue.ts
+++ b/packages/workflow/plugins/queue.ts
@@ -1,7 +1,7 @@
 import fp from 'fastify-plugin'
 import type { FastifyInstance } from 'fastify'
 import { encode } from 'cbor-x'
-import { DuplicateIdempotencyKey, BadRequest } from '../lib/errors.ts'
+import { DuplicateIdempotencyKey, BadRequest, VersionExpired } from '../lib/errors.ts'
 import { checkQueueRateLimit } from '../lib/quotas.ts'
 import type { CborBody } from './cbor.ts'
 
@@ -33,10 +33,26 @@ async function queuePlugin (app: FastifyInstance): Promise<void> {
       throw new BadRequest('queueName and message are required')
     }
 
-    await checkQueueRateLimit(app, appId)
-
     const runId = envelope.message.runId || envelope.message.workflowRunId || ''
     const deploymentVersion = envelope.deploymentId || ''
+
+    await checkQueueRateLimit(app, appId)
+
+    // Fail fast when the target deployment version is expired. routeMessage()
+    // already refuses to dispatch to an expired version, so accepting the
+    // message here only buys it ten doomed delivery attempts before the poller
+    // dead-letters it. 410 is the spec's "this deployment cannot receive the
+    // message" signal, which the World client surfaces through
+    // isDeploymentUnavailableError() so the SDK can re-route instead of retry.
+    // Draining versions still accept work, matching routeMessage().
+    if (deploymentVersion) {
+      const version = await app.pg.query(
+        `SELECT status FROM workflow_deployment_versions
+         WHERE application_id = $1 AND deployment_version = $2`,
+        [appId, deploymentVersion]
+      )
+      if (version.rows[0]?.status === 'expired') throw new VersionExpired(deploymentVersion)
+    }
 
     if (envelope.idempotencyKey) {
       const existing = await app.pg.query(

--- a/packages/workflow/plugins/run-actions.ts
+++ b/packages/workflow/plugins/run-actions.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance } from 'fastify'
 
 const ulid = monotonicFactory()
 import { RunNotFound, BadRequest } from '../lib/errors.ts'
+import { workflowQueueName } from '../queue/names.ts'
 import { formatRun, encodeData } from './events.ts'
 
 async function runActionsPlugin (app: FastifyInstance): Promise<void> {
@@ -52,7 +53,7 @@ async function runActionsPlugin (app: FastifyInstance): Promise<void> {
          ORDER BY id ASC LIMIT 1`,
         [runId, appId]
       )
-      const queueName = originalQueue.rows[0]?.queue_name || `__wkf_workflow_${row.workflow_name}`
+      const queueName = originalQueue.rows[0]?.queue_name || workflowQueueName(row.workflow_name)
       await client.query(
         `INSERT INTO workflow_queue_messages
          (queue_name, run_id, deployment_version, application_id, payload, status)

--- a/packages/workflow/queue/coordinator.ts
+++ b/packages/workflow/queue/coordinator.ts
@@ -1,0 +1,50 @@
+// Decides which process drains the queue.
+//
+// Postgres hands every replica the same table, so exactly one may poll it and
+// leader election is required. A transport whose broker distributes work itself
+// (an SQS queue, a Kafka consumer group) needs no election at all, and passes
+// createAlwaysLeaderCoordinator. Keeping this out of the poller is what makes
+// that a one-line change rather than a rewrite.
+
+import createLeaderElector from '@platformatic/leader'
+import type pg from 'pg'
+
+const LEADER_LOCK_ID = 42424242
+
+export interface Coordinator {
+  start (): void
+  stop (): Promise<void> | void
+  isLeader (): boolean
+}
+
+// For a transport whose broker distributes work itself. It still has to
+// announce leadership: the poller only starts draining when the callback says
+// so, and a coordinator that never calls it would simply never consume.
+export function createAlwaysLeaderCoordinator (
+  onLeadershipChange: (isLeader: boolean) => void
+): Coordinator {
+  return {
+    start () { onLeadershipChange(true) },
+    stop () { onLeadershipChange(false) },
+    isLeader: () => true,
+  }
+}
+
+export function createPostgresCoordinator (
+  pool: pg.Pool, log: any, onLeadershipChange: (isLeader: boolean) => void
+): Coordinator {
+  const leader = createLeaderElector({
+    pool,
+    // Leader election only -- dummy channel required by @platformatic/leader@0.1.0
+    // TODO: remove channels once @platformatic/leader supports election-only mode
+    channels: [],
+    lock: LEADER_LOCK_ID,
+    log,
+    onLeadershipChange,
+  })
+  return {
+    start: () => leader.start(),
+    stop: () => leader.stop(),
+    isLeader: () => leader.isLeader(),
+  }
+}

--- a/packages/workflow/queue/delivery.ts
+++ b/packages/workflow/queue/delivery.ts
@@ -1,0 +1,214 @@
+// Workflow-domain consequences of a queue delivery: what it means for a run, a
+// step, and the event log when a message cannot be delivered.
+//
+// Deliberately separate from the transport that carries the message. Claiming,
+// leasing, acking, retrying and dead-lettering are queue mechanics and could be
+// swapped for another broker; everything here has to happen identically no
+// matter what moved the bytes, because it writes the durable event log the
+// runtime replays.
+
+import type pg from 'pg'
+import { decode, encode } from 'cbor-x'
+import { isStepQueue, isWorkflowQueue, workflowNameFromQueue, workflowQueueNameLike } from './names.ts'
+
+export interface FailureDetail {
+  code: string
+  message: string
+  at: string
+  attempt: number
+  statusCode?: number
+  target: {
+    queueName: string
+    deploymentVersion: string
+    url?: string
+  }
+}
+
+export interface RegisteredTarget {
+  url: string
+}
+
+export function sanitizeTargetUrl (value: string): string | undefined {
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return url.toString().slice(0, 1024)
+  } catch {
+    return undefined
+  }
+}
+
+export function failureDetail (
+  msg: any,
+  attempt: number,
+  code: string,
+  message: string,
+  target?: RegisteredTarget,
+  statusCode?: number
+): FailureDetail {
+  return {
+    code: code.slice(0, 64),
+    message: message.slice(0, 512),
+    at: new Date().toISOString(),
+    attempt,
+    ...(statusCode !== undefined ? { statusCode } : {}),
+    target: {
+      queueName: String(msg.queue_name).slice(0, 256),
+      deploymentVersion: String(msg.deployment_version).slice(0, 256),
+      ...(target?.url ? { url: sanitizeTargetUrl(target.url) } : {}),
+    },
+  }
+}
+
+export function queuePayload (msg: any): any {
+  return msg.payload_encoding === 'cbor' ? decode(msg.payload_bytes) : msg.payload
+}
+
+// A valid v5 devalue payload containing a plain diagnostic object. Keeping the
+// user-facing error small avoids persisting transport response bodies or stacks.
+export function terminalError (failure: FailureDetail): Buffer {
+  const value = [{ name: 1, message: 2, code: 3 }, 'QueueDeliveryError', failure.message, failure.code]
+  return Buffer.from(`devl${JSON.stringify(value)}`)
+}
+
+export function eventError (error: Buffer): Buffer {
+  return Buffer.from(JSON.stringify({ error: error.toString('base64') }))
+}
+
+export async function failRun (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
+  const error = terminalError(failure)
+  const failed = await client.query(
+    `UPDATE workflow_runs
+     SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
+     WHERE id = $1 AND application_id = $2 AND status IN ('pending', 'running')
+     RETURNING id`,
+    [msg.run_id, msg.application_id, error]
+  )
+  if (failed.rows.length === 0) return
+
+  await client.query(
+    `UPDATE workflow_hooks SET status = 'disposed', disposed_at = NOW()
+     WHERE run_id = $1 AND application_id = $2 AND status != 'disposed'`,
+    [msg.run_id, msg.application_id]
+  )
+  await client.query(
+    `UPDATE workflow_waits SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+     WHERE run_id = $1 AND application_id = $2 AND status = 'waiting'`,
+    [msg.run_id, msg.application_id]
+  )
+  await client.query(
+    `INSERT INTO workflow_events (run_id, application_id, event_type, event_data)
+     SELECT $1::varchar, $2::integer, 'run_failed', $3
+     WHERE NOT EXISTS (
+       SELECT 1 FROM workflow_events
+       WHERE run_id = $1 AND application_id = $2 AND event_type = 'run_failed'
+     )`,
+    [msg.run_id, msg.application_id, eventError(error)]
+  )
+}
+
+export async function ensureRunForWorkflowDelivery (client: pg.PoolClient, msg: any): Promise<void> {
+  if (!msg.run_id) return
+  let payload
+  try {
+    payload = queuePayload(msg)
+  } catch {}
+  const runInput = payload?.runInput
+  const workflowName = typeof runInput?.workflowName === 'string'
+    ? runInput.workflowName
+    : workflowNameFromQueue(msg.queue_name)
+  const deploymentId = typeof runInput?.deploymentId === 'string'
+    ? runInput.deploymentId
+    : msg.deployment_version
+
+  await client.query(
+    `INSERT INTO workflow_runs
+       (id, application_id, workflow_name, deployment_id, status, execution_context, spec_version)
+     VALUES ($1, $2, $3, $4, 'pending', $5, $6)
+     ON CONFLICT (id) DO NOTHING`,
+    [msg.run_id, msg.application_id, workflowName || 'unknown', deploymentId || 'unknown',
+      runInput?.executionContext || null, runInput?.specVersion || null]
+  )
+}
+
+export async function failBackgroundStep (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<boolean> {
+  let payload
+  try {
+    payload = queuePayload(msg)
+  } catch {
+    return false
+  }
+  if (!payload || typeof payload.stepId !== 'string') return false
+
+  const step = await client.query(
+    `SELECT s.id, s.status, r.workflow_name
+     FROM workflow_steps s
+     JOIN workflow_runs r ON r.id = s.run_id AND r.application_id = s.application_id
+     WHERE s.run_id = $1 AND s.application_id = $2 AND s.correlation_id = $3
+     FOR UPDATE OF s`,
+    [msg.run_id, msg.application_id, payload.stepId]
+  )
+  // A valid background-step payload must never directly fail the whole run.
+  // A missing/terminal step means another path already resolved its state.
+  if (step.rows.length === 0 || ['completed', 'failed', 'cancelled'].includes(step.rows[0].status)) return true
+
+  const error = terminalError(failure)
+  await client.query(
+    `UPDATE workflow_steps
+     SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
+     WHERE id = $1 AND application_id = $2`,
+    [step.rows[0].id, msg.application_id, error]
+  )
+  await client.query(
+    `INSERT INTO workflow_events
+       (run_id, application_id, event_type, correlation_id, event_data)
+     VALUES ($1, $2, 'step_failed', $3, $4)`,
+    [msg.run_id, msg.application_id, payload.stepId, eventError(error)]
+  )
+
+  const continuation = { runId: msg.run_id }
+  const payloadJson = msg.payload_encoding === 'json' ? JSON.stringify(continuation) : null
+  const payloadBytes = msg.payload_encoding === 'cbor' ? Buffer.from(encode(continuation)) : null
+  await client.query(
+    `INSERT INTO workflow_queue_messages
+       (queue_name, run_id, deployment_version, application_id,
+        payload, payload_bytes, payload_encoding, status)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
+    [workflowQueueNameLike(msg.queue_name, step.rows[0].workflow_name), msg.run_id, msg.deployment_version,
+      msg.application_id, payloadJson, payloadBytes, msg.payload_encoding]
+  )
+  await client.query("SELECT pg_notify('deferred_messages', '{}')")
+  return true
+}
+
+export async function finalizeFailure (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
+  // v5 dispatches background steps through the workflow queue, while v4 uses
+  // a dedicated step queue. The payload is the authoritative discriminator.
+  if (await failBackgroundStep(client, msg, failure)) return
+  if (isWorkflowQueue(msg.queue_name)) {
+    await failRun(client, msg, failure)
+  } else if (isStepQueue(msg.queue_name)) {
+    await failRun(client, msg, failure)
+  }
+}
+
+export async function lockRunForFailureFinalization (client: pg.PoolClient, msg: any): Promise<void> {
+  if (!msg.run_id) return
+  if (isWorkflowQueue(msg.queue_name)) await ensureRunForWorkflowDelivery(client, msg)
+  await client.query(
+    'SELECT id FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
+    [msg.run_id, msg.application_id]
+  )
+}
+
+// A message stuck in 'delivered' means its executor never reported back, most
+// likely because it died mid-step. Nothing else reclaims it: the retry paths
+// only touch 'pending', 'deferred' and 'failed'. Redelivering resumes the run
+// rather than failing it.
+//
+// Deliberately scoped to messages, not runs. A run with no message outstanding
+// is idle, not stuck -- it may be parked on a hook for days -- and inactivity
+// is not a fault in a durable workflow.

--- a/packages/workflow/queue/factory.ts
+++ b/packages/workflow/queue/factory.ts
@@ -1,0 +1,56 @@
+// Selects the queue transport.
+//
+// WF_QUEUE_DRIVER names the transport; the store is always Postgres, because
+// scheduling, dedupe, status and dead letters are workflow semantics rather
+// than broker operations (see ../QUEUE-PLUGGABILITY.md). Unset means postgres,
+// so an install that configures nothing keeps exactly the queue it has today.
+//
+// A backend brings its own coordinator, so adding a transport means adding a
+// case here and nothing else. A broker that distributes work itself passes
+// createAlwaysLeaderCoordinator from ./coordinator.ts as its makeCoordinator.
+
+import type pg from 'pg'
+import { createPostgresQueueStore } from './stores/postgres.ts'
+import { createPostgresTransport } from './transports/postgres.ts'
+import { createPostgresCoordinator, type Coordinator } from './coordinator.ts'
+import type { QueueStore } from './store.ts'
+import type { BrokerTransport } from './transport.ts'
+
+export type CoordinatorFactory = (onLeadershipChange: (isLeader: boolean) => void) => Coordinator
+
+export interface QueueBackend {
+  driver: string
+  store: QueueStore
+  transport: BrokerTransport
+  // Whether this backend needs an elected leader. Postgres does: every replica
+  // sees the same table. A broker that distributes work itself does not, and
+  // says so here rather than in the plugin, so registering a backend is the
+  // only change a new transport requires.
+  makeCoordinator: CoordinatorFactory
+}
+
+export const DEFAULT_QUEUE_DRIVER = 'postgres'
+
+export function resolveQueueDriver (): string {
+  return process.env.WF_QUEUE_DRIVER || DEFAULT_QUEUE_DRIVER
+}
+
+export function createQueueBackend (
+  pool: pg.Pool, connectionString: string, log: any, driver = resolveQueueDriver()
+): QueueBackend {
+  switch (driver) {
+    case 'postgres': {
+      const store = createPostgresQueueStore(pool, log, driver)
+      return {
+        driver,
+        store,
+        transport: createPostgresTransport(store, connectionString, log),
+        makeCoordinator: (onChange) => createPostgresCoordinator(pool, log, onChange),
+      }
+    }
+    default:
+      throw new Error(
+        `Unknown WF_QUEUE_DRIVER ${JSON.stringify(driver)}. Supported: ${DEFAULT_QUEUE_DRIVER}`
+      )
+  }
+}

--- a/packages/workflow/queue/names.ts
+++ b/packages/workflow/queue/names.ts
@@ -1,0 +1,54 @@
+// Queue-name grammar, mirroring @workflow/world's queue.ts.
+//
+// Restated rather than imported because this service does not depend on
+// @workflow/world (the same call made for slot identity in plugins/events.ts).
+// The patterns are copied from the spec so a namespaced deployment routes here
+// exactly as it does in the SDK.
+//
+// The spec supports an optional namespace between the sentinel and the kind:
+//
+//   __wkf_workflow_<id>              (default)
+//   __{namespace}_wkf_workflow_<id>  (WORKFLOW_QUEUE_NAMESPACE)
+//
+// Matching on the bare `__wkf_workflow_` literal silently misses the namespaced
+// form, which is how a namespaced workflow message ends up dispatched to the
+// webhook handler.
+
+// Spec: /^__(?:[a-z][a-z0-9]*_)?wkf_workflow_.+$/
+const WORKFLOW_QUEUE_RE = /^__(?:[a-z][a-z0-9]*_)?wkf_workflow_(.+)$/
+// v4 dispatched background steps on their own prefix; v5 folded them into the
+// workflow queue and dropped it. Still recognised so a v4 runtime keeps routing.
+const STEP_QUEUE_RE = /^__(?:[a-z][a-z0-9]*_)?wkf_step_(.+)$/
+// Everything up to and including the kind, e.g. `__acme_wkf_workflow_`.
+const QUEUE_PREFIX_RE = /^(__(?:[a-z][a-z0-9]*_)?wkf_(?:workflow|step)_)/
+
+export function isWorkflowQueue (queueName: string): boolean {
+  return WORKFLOW_QUEUE_RE.test(queueName)
+}
+
+export function isStepQueue (queueName: string): boolean {
+  return STEP_QUEUE_RE.test(queueName)
+}
+
+// The workflow id carried in the queue name, namespace or not.
+export function workflowNameFromQueue (queueName: string): string | undefined {
+  return WORKFLOW_QUEUE_RE.exec(queueName)?.[1]
+}
+
+export function resolveQueueNamespace (namespace?: string): string | undefined {
+  return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined
+}
+
+export function workflowQueueName (workflowName: string, namespace?: string): string {
+  const ns = resolveQueueNamespace(namespace)
+  return ns ? `__${ns}_wkf_workflow_${workflowName}` : `__wkf_workflow_${workflowName}`
+}
+
+// A workflow queue name in the same namespace as `sourceQueueName`. Used when a
+// delivery spawns a follow-up message: the continuation belongs on the queue the
+// original arrived on, not on whatever this process's env happens to say.
+export function workflowQueueNameLike (sourceQueueName: string, workflowName: string): string {
+  const prefix = QUEUE_PREFIX_RE.exec(sourceQueueName)?.[1]
+  if (!prefix) return workflowQueueName(workflowName)
+  return `${prefix.replace(/wkf_step_$/, 'wkf_workflow_')}${workflowName}`
+}

--- a/packages/workflow/queue/names.ts
+++ b/packages/workflow/queue/names.ts
@@ -35,13 +35,27 @@ export function workflowNameFromQueue (queueName: string): string | undefined {
   return WORKFLOW_QUEUE_RE.exec(queueName)?.[1]
 }
 
+// Spec: /^[a-z][a-z0-9]*$/
+const QUEUE_NAMESPACE_RE = /^[a-z][a-z0-9]*$/
+
+// Mirrors the spec's resolveQueueNamespace: reads, does not validate.
 export function resolveQueueNamespace (namespace?: string): string | undefined {
   return namespace ?? process.env.WORKFLOW_QUEUE_NAMESPACE ?? undefined
 }
 
 export function workflowQueueName (workflowName: string, namespace?: string): string {
   const ns = resolveQueueNamespace(namespace)
-  return ns ? `__${ns}_wkf_workflow_${workflowName}` : `__wkf_workflow_${workflowName}`
+  if (ns === undefined) return `__wkf_workflow_${workflowName}`
+  // Validate where the prefix is built, as the spec's getQueueTopicPrefix does.
+  // An unchecked namespace produces a name no matcher recognises, which routes
+  // to the webhook handler instead of the workflow one -- the exact silent
+  // misroute this module exists to prevent. Fail loudly on misconfiguration.
+  if (!QUEUE_NAMESPACE_RE.test(ns)) {
+    throw new Error(
+      `Invalid WORKFLOW_QUEUE_NAMESPACE ${JSON.stringify(ns)}: must be lowercase alphanumeric, starting with a letter`
+    )
+  }
+  return `__${ns}_wkf_workflow_${workflowName}`
 }
 
 // A workflow queue name in the same namespace as `sourceQueueName`. Used when a

--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -1,342 +1,107 @@
-import pg from 'pg'
-import createLeaderElector from '@platformatic/leader'
-import { decode, encode } from 'cbor-x'
+// Drains the queue and delivers each message to the pod that should run it.
+//
+// Three collaborators, and the split matters:
+//   - QueueStore (./store.ts)      durable state. Always Postgres.
+//   - BrokerTransport (./transport.ts)  carries ready messages. Pluggable.
+//   - the delivery policy below    routing, dispatch, retry, finalization. Ours.
+//
+// The Postgres pool is still a parameter, but only for the routing table:
+// registered handlers are our data, not the broker's, whatever moves the bytes.
+
+import type pg from 'pg'
 import { routeMessage } from './router.ts'
 import { dispatchMessage, type DispatchResult } from './dispatcher.ts'
-import { getRetryDelay, isMaxAttempts, MAX_ATTEMPTS } from './retry.ts'
-import { isStepQueue, isWorkflowQueue, workflowNameFromQueue, workflowQueueNameLike } from './names.ts'
+import { getRetryDelay, isMaxAttempts } from './retry.ts'
+import {
+  failureDetail,
+  finalizeFailure,
+  lockRunForFailureFinalization,
+  type RegisteredTarget,
+} from './delivery.ts'
+import type { FailureFinalizer, QueueMessage, QueueStore } from './store.ts'
+import type { BrokerTransport } from './transport.ts'
+import type { Coordinator } from './coordinator.ts'
 
 // How often delivered-but-unacknowledged messages are reclaimed.
 const RECLAIM_CHECK_INTERVAL = 60_000
-// How long a message may stay 'delivered' before it is assumed its executor
-// died and it is redelivered. This bounds a single step, not a whole run: a
-// run may idle for days on a hook without any message outstanding, and that is
-// not a fault. Must exceed the slowest legitimate step (model calls included).
-const DEFAULT_VISIBILITY_TIMEOUT_S = 900
-const VISIBILITY_TIMEOUT_S = Number(process.env.WF_DELIVERY_VISIBILITY_TIMEOUT_S) > 0
-  ? Number(process.env.WF_DELIVERY_VISIBILITY_TIMEOUT_S)
-  : DEFAULT_VISIBILITY_TIMEOUT_S
-// Safety-net poll interval: scheduleNextWakeup() is fire-and-forget to avoid
-// blocking pendingNotify re-runs. When multiple executeOnce() cycles run
-// back-to-back, two concurrent scheduleNextWakeup() calls can race — the
-// second clears the first's deferredTimer, then queries the DB after the
-// deferred message's deliver_at has passed NOW(), finding nothing to schedule.
-// The deferred message is stuck: deliver_at in the past but status still
-// 'deferred', with no timer or notification to trigger promotion.
-// This interval ensures executeOnce() runs periodically regardless, so any
-// stuck deferred messages are promoted within a bounded time window.
+// Safety-net poll interval. scheduleNextWakeup() is fire-and-forget so it does
+// not block pendingNotify re-runs, which means two cycles can race and leave a
+// due message with no timer pointing at it. This bounds how long that lasts.
 const SAFETY_POLL_INTERVAL = 5_000
-const LEADER_LOCK_ID = 42424242
-const DEFERRED_CHANNEL = 'deferred_messages'
-// Upper bound on dispatches in flight at once. Each dispatch is an independent
-// task (see processMessage), so a single slow/hung handler can no longer block
-// the poll loop; this cap just bounds concurrency and the in-flight set size.
+// Upper bound on dispatches in flight at once. Each is its own task, so one
+// slow handler cannot block the loop; this just bounds concurrency.
 const MAX_INFLIGHT = 200
+// Outbox entries handed to the broker per cycle.
+const RELAY_BATCH = 100
 
-interface FailureDetail {
-  code: string
-  message: string
-  at: string
-  attempt: number
-  statusCode?: number
-  target: {
-    queueName: string
-    deploymentVersion: string
-    url?: string
+// The domain half of a terminal failure, handed to the store so it can run
+// inside the transaction that records the dead letter.
+export const failureFinalizer: FailureFinalizer = {
+  lock: lockRunForFailureFinalization,
+  finalize: finalizeFailure,
+}
+
+// No pod is registered for this message's deployment version, or that version
+// expired. Retry under the ceiling, then give up: it can never be delivered to
+// code that would understand it.
+export async function onNoRoute (store: QueueStore, msg: QueueMessage): Promise<void> {
+  const attempts = msg.attempts + 1
+  const failure = failureDetail(
+    msg, attempts, 'ROUTE_NOT_FOUND',
+    'No registered target is available for this queue delivery'
+  )
+  if (isMaxAttempts(attempts)) await store.deadLetter(msg, failure, failureFinalizer)
+  else await store.scheduleRetry(msg, getRetryDelay(attempts), failure)
+}
+
+export async function onDispatchResult (
+  store: QueueStore,
+  msg: QueueMessage,
+  result: DispatchResult,
+  target?: RegisteredTarget
+): Promise<void> {
+  if (result.success) {
+    // A numeric timeoutSeconds means the handler asked to be called back: 0 for
+    // immediately, more for a deferred re-invocation (the 425 retryAfter path).
+    const continuation = typeof result.timeoutSeconds === 'number'
+      ? { delaySeconds: result.timeoutSeconds }
+      : undefined
+    await store.ack(msg, continuation)
+    return
   }
+
+  const attempts = msg.attempts + 1
+  const error = result.error || { code: 'DISPATCH_ERROR', message: 'Target request failed' }
+  const failure = failureDetail(msg, attempts, error.code, error.message, target, result.statusCode)
+
+  if (isMaxAttempts(attempts)) await store.deadLetter(msg, failure, failureFinalizer)
+  else await store.scheduleRetry(msg, getRetryDelay(attempts), failure)
 }
 
-interface RegisteredTarget {
-  url: string
-}
-
-export function sanitizeTargetUrl (value: string): string | undefined {
-  try {
-    const url = new URL(value)
-    url.username = ''
-    url.password = ''
-    url.search = ''
-    url.hash = ''
-    return url.toString().slice(0, 1024)
-  } catch {
-    return undefined
-  }
-}
-
-function failureDetail (
-  msg: any,
-  attempt: number,
-  code: string,
-  message: string,
-  target?: RegisteredTarget,
-  statusCode?: number
-): FailureDetail {
-  return {
-    code: code.slice(0, 64),
-    message: message.slice(0, 512),
-    at: new Date().toISOString(),
-    attempt,
-    ...(statusCode !== undefined ? { statusCode } : {}),
-    target: {
-      queueName: String(msg.queue_name).slice(0, 256),
-      deploymentVersion: String(msg.deployment_version).slice(0, 256),
-      ...(target?.url ? { url: sanitizeTargetUrl(target.url) } : {}),
-    },
-  }
-}
-
-function queuePayload (msg: any): any {
-  return msg.payload_encoding === 'cbor' ? decode(msg.payload_bytes) : msg.payload
-}
-
-// A valid v5 devalue payload containing a plain diagnostic object. Keeping the
-// user-facing error small avoids persisting transport response bodies or stacks.
-function terminalError (failure: FailureDetail): Buffer {
-  const value = [{ name: 1, message: 2, code: 3 }, 'QueueDeliveryError', failure.message, failure.code]
-  return Buffer.from(`devl${JSON.stringify(value)}`)
-}
-
-function eventError (error: Buffer): Buffer {
-  return Buffer.from(JSON.stringify({ error: error.toString('base64') }))
-}
-
-async function failRun (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
-  const error = terminalError(failure)
-  const failed = await client.query(
-    `UPDATE workflow_runs
-     SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
-     WHERE id = $1 AND application_id = $2 AND status IN ('pending', 'running')
-     RETURNING id`,
-    [msg.run_id, msg.application_id, error]
-  )
-  if (failed.rows.length === 0) return
-
-  await client.query(
-    `UPDATE workflow_hooks SET status = 'disposed', disposed_at = NOW()
-     WHERE run_id = $1 AND application_id = $2 AND status != 'disposed'`,
-    [msg.run_id, msg.application_id]
-  )
-  await client.query(
-    `UPDATE workflow_waits SET status = 'completed', completed_at = NOW(), updated_at = NOW()
-     WHERE run_id = $1 AND application_id = $2 AND status = 'waiting'`,
-    [msg.run_id, msg.application_id]
-  )
-  await client.query(
-    `INSERT INTO workflow_events (run_id, application_id, event_type, event_data)
-     SELECT $1::varchar, $2::integer, 'run_failed', $3
-     WHERE NOT EXISTS (
-       SELECT 1 FROM workflow_events
-       WHERE run_id = $1 AND application_id = $2 AND event_type = 'run_failed'
-     )`,
-    [msg.run_id, msg.application_id, eventError(error)]
-  )
-}
-
-async function ensureRunForWorkflowDelivery (client: pg.PoolClient, msg: any): Promise<void> {
-  if (!msg.run_id) return
-  let payload
-  try {
-    payload = queuePayload(msg)
-  } catch {}
-  const runInput = payload?.runInput
-  const workflowName = typeof runInput?.workflowName === 'string'
-    ? runInput.workflowName
-    : workflowNameFromQueue(msg.queue_name)
-  const deploymentId = typeof runInput?.deploymentId === 'string'
-    ? runInput.deploymentId
-    : msg.deployment_version
-
-  await client.query(
-    `INSERT INTO workflow_runs
-       (id, application_id, workflow_name, deployment_id, status, execution_context, spec_version)
-     VALUES ($1, $2, $3, $4, 'pending', $5, $6)
-     ON CONFLICT (id) DO NOTHING`,
-    [msg.run_id, msg.application_id, workflowName || 'unknown', deploymentId || 'unknown',
-      runInput?.executionContext || null, runInput?.specVersion || null]
-  )
-}
-
-async function failBackgroundStep (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<boolean> {
-  let payload
-  try {
-    payload = queuePayload(msg)
-  } catch {
-    return false
-  }
-  if (!payload || typeof payload.stepId !== 'string') return false
-
-  const step = await client.query(
-    `SELECT s.id, s.status, r.workflow_name
-     FROM workflow_steps s
-     JOIN workflow_runs r ON r.id = s.run_id AND r.application_id = s.application_id
-     WHERE s.run_id = $1 AND s.application_id = $2 AND s.correlation_id = $3
-     FOR UPDATE OF s`,
-    [msg.run_id, msg.application_id, payload.stepId]
-  )
-  // A valid background-step payload must never directly fail the whole run.
-  // A missing/terminal step means another path already resolved its state.
-  if (step.rows.length === 0 || ['completed', 'failed', 'cancelled'].includes(step.rows[0].status)) return true
-
-  const error = terminalError(failure)
-  await client.query(
-    `UPDATE workflow_steps
-     SET status = 'failed', error = $3, completed_at = NOW(), updated_at = NOW()
-     WHERE id = $1 AND application_id = $2`,
-    [step.rows[0].id, msg.application_id, error]
-  )
-  await client.query(
-    `INSERT INTO workflow_events
-       (run_id, application_id, event_type, correlation_id, event_data)
-     VALUES ($1, $2, 'step_failed', $3, $4)`,
-    [msg.run_id, msg.application_id, payload.stepId, eventError(error)]
-  )
-
-  const continuation = { runId: msg.run_id }
-  const payloadJson = msg.payload_encoding === 'json' ? JSON.stringify(continuation) : null
-  const payloadBytes = msg.payload_encoding === 'cbor' ? Buffer.from(encode(continuation)) : null
-  await client.query(
-    `INSERT INTO workflow_queue_messages
-       (queue_name, run_id, deployment_version, application_id,
-        payload, payload_bytes, payload_encoding, status)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
-    [workflowQueueNameLike(msg.queue_name, step.rows[0].workflow_name), msg.run_id, msg.deployment_version,
-      msg.application_id, payloadJson, payloadBytes, msg.payload_encoding]
-  )
-  await client.query("SELECT pg_notify('deferred_messages', '{}')")
-  return true
-}
-
-async function finalizeFailure (client: pg.PoolClient, msg: any, failure: FailureDetail): Promise<void> {
-  // v5 dispatches background steps through the workflow queue, while v4 uses
-  // a dedicated step queue. The payload is the authoritative discriminator.
-  if (await failBackgroundStep(client, msg, failure)) return
-  if (isWorkflowQueue(msg.queue_name)) {
-    await failRun(client, msg, failure)
-  } else if (isStepQueue(msg.queue_name)) {
-    await failRun(client, msg, failure)
-  }
-}
-
-async function lockRunForFailureFinalization (client: pg.PoolClient, msg: any): Promise<void> {
-  if (!msg.run_id) return
-  if (isWorkflowQueue(msg.queue_name)) await ensureRunForWorkflowDelivery(client, msg)
-  await client.query(
-    'SELECT id FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
-    [msg.run_id, msg.application_id]
-  )
-}
-
-// A message stuck in 'delivered' means its executor never reported back, most
-// likely because it died mid-step. Nothing else reclaims it: the retry paths
-// only touch 'pending', 'deferred' and 'failed'. Redelivering resumes the run
-// rather than failing it.
-//
-// Deliberately scoped to messages, not runs. A run with no message outstanding
-// is idle, not stuck -- it may be parked on a hook for days -- and inactivity
-// is not a fault in a durable workflow.
-export async function reclaimExpiredDeliveries (
-  client: pg.PoolClient,
+export function createPoller (
+  store: QueueStore,
+  transport: BrokerTransport,
+  pool: pg.Pool,
   log: any,
-  visibilityTimeoutS: number = VISIBILITY_TIMEOUT_S
-): Promise<number> {
-  try {
-    // Under the retry ceiling: hand it back to the poller for another attempt.
-    const reclaimed = await client.query(
-      `UPDATE workflow_queue_messages m
-       SET status = 'pending', attempts = m.attempts + 1,
-           delivered_at = NULL, updated_at = NOW()
-       FROM workflow_runs r
-       WHERE m.run_id = r.id
-         AND m.status = 'delivered'
-         AND m.delivered_at < NOW() - make_interval(secs => $1)
-         AND r.status IN ('pending', 'running')
-         AND m.attempts < $2
-       RETURNING m.id, m.run_id, m.queue_name, m.attempts`,
-      [visibilityTimeoutS, MAX_ATTEMPTS]
-    )
-
-    if (reclaimed.rows.length > 0) {
-      log.warn(
-        { count: reclaimed.rows.length, visibilityTimeoutS },
-        'Reclaimed delivered messages whose executor never reported back'
-      )
-    }
-
-    // At the ceiling there is nothing left to retry, so finalize rather than
-    // leave the run running forever.
-    const exhausted = await client.query(
-      `SELECT m.id, m.run_id, m.application_id, m.queue_name, m.deployment_version, m.attempts
-       FROM workflow_queue_messages m
-       JOIN workflow_runs r ON r.id = m.run_id
-       WHERE m.status = 'delivered'
-         AND m.delivered_at < NOW() - make_interval(secs => $1)
-         AND r.status IN ('pending', 'running')
-         AND m.attempts >= $2
-       LIMIT 10`,
-      [visibilityTimeoutS, MAX_ATTEMPTS]
-    )
-
-    for (const msg of exhausted.rows) {
-      await client.query('BEGIN')
-      try {
-        const failure = failureDetail(
-          msg, msg.attempts, 'DELIVERY_TIMEOUT',
-          `Message delivered but never acknowledged within ${visibilityTimeoutS}s, and retries are exhausted`
-        )
-        await lockRunForFailureFinalization(client, msg)
-        await client.query(
-          `UPDATE workflow_queue_messages
-           SET status = 'dead', last_failure = $3, dead_at = NOW(),
-               failure_finalized_at = NOW(), updated_at = NOW()
-           WHERE id = $1 AND application_id = $2 AND status = 'delivered'`,
-          [msg.id, msg.application_id, failure]
-        )
-        await failRun(client, msg, failure)
-        await client.query('COMMIT')
-      } catch (err) {
-        await client.query('ROLLBACK')
-        throw err
-      }
-    }
-    return reclaimed.rows.length
-  } catch (err) {
-    log.error({ err }, 'Delivery reclaim error')
-    return 0
-  }
-}
-
-export function createPoller (pool: pg.Pool, connectionString: string, log: any) {
-  let stopped = false
+  makeCoordinator: (onLeadershipChange: (isLeader: boolean) => void) => Coordinator
+) {
+  // Starts true: nothing is drained until the coordinator grants leadership, so
+  // a wake-up that arrives before then is a no-op rather than an unelected poll.
+  let stopped = true
   let deferredTimer: ReturnType<typeof setTimeout> | null = null
   let reclaimTimer: ReturnType<typeof setInterval> | null = null
   let safetyTimer: ReturnType<typeof setInterval> | null = null
-  let listenClient: pg.Client | null = null
   let executing = false
   let pendingNotify = false
-  // Messages currently being dispatched in their own task. They stay 'pending'
-  // in the DB until their task resolves, so a crash re-dispatches them; this set
-  // just prevents the next poll from picking them up again while in flight.
-  const inFlight = new Set<number>()
+  const inFlight = new Set<string>()
 
-  // Leader election only — dummy channel required by @platformatic/leader@0.1.0
-  // TODO: remove channels once @platformatic/leader supports election-only mode
-  const leader = createLeaderElector({
-    pool,
-    lock: LEADER_LOCK_ID,
-    log,
-    channels: [],
-    onLeadershipChange: (isLeader: boolean) => {
-      if (isLeader) {
-        startPolling()
-      } else {
-        stopPolling()
-      }
-    },
+  const coordinator = makeCoordinator((isLeader: boolean) => {
+    if (isLeader) startPolling()
+    else stopPolling()
   })
 
   function startPolling (): void {
     stopped = false
-    setupListener()
     reclaimTimer = setInterval(runReclaim, RECLAIM_CHECK_INTERVAL)
     safetyTimer = setInterval(() => execute(), SAFETY_POLL_INTERVAL)
     execute()
@@ -347,52 +112,15 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
     if (deferredTimer) { clearTimeout(deferredTimer); deferredTimer = null }
     if (reclaimTimer) { clearInterval(reclaimTimer); reclaimTimer = null }
     if (safetyTimer) { clearInterval(safetyTimer); safetyTimer = null }
-    teardownListener()
-  }
-
-  // Dedicated LISTEN client — not from the pool
-  function setupListener (): void {
-    listenClient = new pg.Client({ connectionString })
-    listenClient.on('error', (err) => {
-      log.error({ err }, 'LISTEN connection error')
-      if (!stopped && leader.isLeader()) {
-        setTimeout(() => setupListener(), 1000)
-      }
-    })
-
-    listenClient.connect()
-      .then(() => listenClient!.query(`LISTEN "${DEFERRED_CHANNEL}"`))
-      .then(() => {
-        log.info({ channel: DEFERRED_CHANNEL }, 'Listening to notification channel')
-      })
-      .catch((err) => {
-        log.error({ err }, 'Failed to setup LISTEN connection')
-        if (!stopped && leader.isLeader()) {
-          setTimeout(() => setupListener(), 1000)
-        }
-      })
-
-    listenClient.on('notification', () => {
-      execute()
-    })
-  }
-
-  function teardownListener (): void {
-    if (listenClient) {
-      listenClient.end().catch(() => {})
-      listenClient = null
-    }
   }
 
   async function execute (): Promise<void> {
     if (stopped) return
-
     if (executing) {
       pendingNotify = true
       return
     }
     executing = true
-
     try {
       await executeOnce()
     } finally {
@@ -405,87 +133,78 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
   }
 
   async function executeOnce (): Promise<void> {
-    const client = await pool.connect()
     try {
-      // 1. Finalize failures for rows left at the retry ceiling by older pollers.
-      const exhausted = await client.query(
-        `SELECT * FROM workflow_queue_messages
-         WHERE status = 'failed' AND attempts >= 10
-         ORDER BY created_at ASC
-         LIMIT 100`
-      )
-      for (const msg of exhausted.rows) {
-        await handleExhaustedMessage(client, msg)
+      // 1. Finalize messages left at the retry ceiling.
+      for (const msg of await store.claimExhausted(100)) {
+        await store.finalizeExhausted(msg, failureFinalizer)
       }
 
-      // 2. Promote deferred messages that are due
-      await client.query(
-        `UPDATE workflow_queue_messages
-         SET status = 'pending', updated_at = NOW()
-         WHERE status = 'deferred' AND deliver_at <= NOW()`
-      )
+      // 2. Promote deferred and retry-due messages.
+      await store.promoteDue()
 
-      // 3. Retry failed messages that are due
-      await client.query(
-        `UPDATE workflow_queue_messages
-         SET status = 'pending', updated_at = NOW()
-         WHERE status = 'failed' AND next_retry_at <= NOW() AND attempts < 10`
-      )
+      // 3. Outbox relay: hand committed-but-unpublished messages to the broker.
+      // Empty for the Postgres transport, where the two commit together.
+      await relayOutbox()
 
-      // 4. Claim pending messages (excluding those already in flight) and
-      // dispatch each in its own task. We do NOT await the dispatches here:
-      // a single slow or hung handler must not block the poll loop (the
-      // single-flight `executing` guard would otherwise freeze the whole queue
-      // for up to the dispatch bodyTimeout). Each task updates its own message.
+      // 4. Take ready messages from the transport and dispatch each in its own
+      // task. We do NOT await them: one slow handler must not block the loop.
       const capacity = MAX_INFLIGHT - inFlight.size
       if (capacity > 0) {
-        const inFlightIds = Array.from(inFlight)
-        const pending = await client.query(
-          `SELECT * FROM workflow_queue_messages
-           WHERE status = 'pending' AND NOT (id = ANY($1::bigint[]))
-           ORDER BY created_at ASC
-           FOR UPDATE SKIP LOCKED
-           LIMIT $2`,
-          [inFlightIds, capacity]
-        )
-
-        for (const msg of pending.rows) {
-          if (inFlight.has(msg.id)) continue
-          inFlight.add(msg.id)
-          // Fire-and-forget: the task owns its message's result handling.
-          processMessage(msg)
+        for (const leased of await transport.receive(capacity)) {
+          if (inFlight.has(leased.leaseId)) continue
+          inFlight.add(leased.leaseId)
+          processMessage(leased.messageId, leased.leaseId)
         }
       }
 
-      // 5. Schedule next wake-up based on earliest deferred/retry message
-      // Fire-and-forget: must not block executeOnce so pendingNotify re-runs
-      // are not delayed, and so re-runs use their own pool connection for the query
+      // 5. Schedule the next wake-up. Fire-and-forget so pendingNotify re-runs
+      // are not delayed behind it.
       scheduleNextWakeup()
     } catch (err) {
       log.error({ err }, 'Executor error')
-    } finally {
-      client.release()
     }
   }
 
-  // Dispatch a single message and persist its result on a dedicated client, so
-  // a slow handler ties up only its own task (and one connection, briefly, for
-  // the result write) rather than the shared poll loop. The message stays
-  // 'pending' until this resolves; on completion it is removed from `inFlight`
-  // so a failed dispatch is retried on the next poll.
-  async function processMessage (msg: any): Promise<void> {
+  // Commit-then-publish. A crash before publishing leaves the entry for the next
+  // cycle; a crash between publishing and marking republishes, which the
+  // dispatch gate below makes harmless.
+  async function relayOutbox (): Promise<void> {
+    const entries = await store.takeUnpublished(RELAY_BATCH)
+    for (const entry of entries) {
+      try {
+        await transport.publish(entry.messageId, entry)
+        await store.markPublished(entry.messageId)
+      } catch (err) {
+        log.error({ err, messageId: entry.messageId }, 'Outbox publish failed; will retry')
+        return
+      }
+    }
+  }
+
+  async function processMessage (messageId: QueueMessage['id'], leaseId: string): Promise<void> {
+    let claimed: QueueMessage | null = null
     try {
+      // The gate. Postgres decides whether this message may run, not the broker.
+      // A redelivery of something already delivered, dead or failed loses the
+      // compare-and-set and is dropped here, before it can reach the handler.
+      const msg = await store.claimForDispatch(messageId)
+      if (!msg) {
+        await transport.ack(leaseId)
+        return
+      }
+      claimed = msg
+
       const route = await routeMessage(pool, msg.application_id, msg.deployment_version, msg.queue_name)
       if (!route) {
-        const client = await pool.connect()
-        try { await handleNoRoute(client, msg) } finally { client.release() }
+        await onNoRoute(store, msg)
+        await transport.ack(leaseId)
         return
       }
 
       const result = await dispatchMessage({
         url: route.url,
         queueName: msg.queue_name,
-        messageId: msg.id,
+        messageId: msg.id as number,
         payload: msg.payload,
         payloadBytes: msg.payload_bytes,
         payloadEncoding: msg.payload_encoding,
@@ -493,29 +212,36 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
       })
       log.info(`[POLLER] dispatched msgId=${msg.id} queue=${msg.queue_name} encoding=${msg.payload_encoding} status=${result.statusCode} timeoutSeconds=${result.timeoutSeconds} success=${result.success}`)
 
-      const client = await pool.connect()
-      try { await handleDispatchResult(client, msg, result, route) } finally { client.release() }
+      await onDispatchResult(store, msg, result, route)
+      await transport.ack(leaseId)
     } catch (err) {
-      // Leave the message 'pending'; removing it from inFlight (below) lets the
-      // next poll retry it.
-      log.error({ err, msgId: msg.id }, 'Dispatch task error')
+      // Nothing was recorded for this delivery, so hand the broker's copy back
+      // rather than leaving it leased. The store still has the row as
+      // 'delivered' and reclaimExpired is the backstop if the release is lost.
+      log.error({ err, msgId: messageId }, 'Dispatch task error')
+      // Return the claim first, then the lease. The other order re-offers a
+      // message the store would still refuse to hand out.
+      if (claimed) {
+        await store.releaseClaim(claimed).catch((claimErr) => {
+          log.error({ err: claimErr, msgId: messageId }, 'Failed to release queue claim')
+        })
+      }
+      await transport.release(leaseId).catch((releaseErr) => {
+        log.error({ err: releaseErr, msgId: messageId }, 'Failed to release queue lease')
+      })
     } finally {
-      inFlight.delete(msg.id)
-      // A slot freed up — nudge the poller in case messages are waiting.
+      inFlight.delete(leaseId)
       if (!stopped) execute()
     }
   }
 
   async function runReclaim (): Promise<void> {
     if (stopped) return
-    const client = await pool.connect()
     try {
-      const reclaimed = await reclaimExpiredDeliveries(client, log)
+      const reclaimed = await store.reclaimExpired()
       if (reclaimed > 0) execute()
     } catch (err) {
       log.error({ err }, 'Delivery reclaim error')
-    } finally {
-      client.release()
     }
   }
 
@@ -525,22 +251,9 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
       clearTimeout(deferredTimer)
       deferredTimer = null
     }
-
     try {
-      const result = await pool.query(
-        `SELECT EXTRACT(EPOCH FROM (MIN(next_time) - NOW())) AS secs
-         FROM (
-           SELECT deliver_at AS next_time FROM workflow_queue_messages
-             WHERE status = 'deferred' AND deliver_at > NOW()
-           UNION ALL
-           SELECT next_retry_at AS next_time FROM workflow_queue_messages
-             WHERE status = 'failed' AND next_retry_at > NOW() AND attempts < 10
-         ) t`
-      )
-
-      const secs = result.rows[0]?.secs
-      if (secs !== null && secs !== undefined) {
-        const ms = Math.max(Math.ceil(Number(secs) * 1000), 50)
+      const ms = await store.nextWakeupMs()
+      if (ms !== null) {
         deferredTimer = setTimeout(() => {
           deferredTimer = null
           execute()
@@ -553,156 +266,20 @@ export function createPoller (pool: pg.Pool, connectionString: string, log: any)
 
   return {
     start () {
-      stopped = false
-      leader.start()
+      // Subscribed once, for the life of the process, not per leadership term.
+      // Re-subscribing on every acquisition would leak a connection each time a
+      // leader lost and regained the lock, and the wake-up itself is harmless
+      // when this instance is not the leader: execute() returns early.
+      transport.subscribe(() => execute()).catch((err) => {
+        log.error({ err }, 'Failed to subscribe to queue notifications')
+      })
+      coordinator.start()
     },
     async stop () {
       stopped = true
       stopPolling()
-      teardownListener()
-      await leader.stop()
+      await transport.close()
+      await coordinator.stop()
     },
-  }
-}
-
-export async function handleExhaustedMessage (client: pg.PoolClient, msg: any): Promise<void> {
-  const failure = msg.last_failure || failureDetail(
-    msg,
-    msg.attempts,
-    'RETRY_EXHAUSTED',
-    'Queue delivery exhausted all retry attempts'
-  )
-
-  await client.query('BEGIN')
-  try {
-    await lockRunForFailureFinalization(client, msg)
-    const updated = await client.query(
-      `UPDATE workflow_queue_messages
-       SET status = 'dead', last_failure = $4, dead_at = NOW(), failure_finalized_at = NOW(),
-           next_retry_at = NULL, updated_at = NOW()
-       WHERE id = $1 AND application_id = $2 AND status = 'failed' AND attempts = $3
-       RETURNING id`,
-      [msg.id, msg.application_id, msg.attempts, failure]
-    )
-    if (updated.rows.length > 0) await finalizeFailure(client, msg, failure)
-    await client.query('COMMIT')
-  } catch (err) {
-    await client.query('ROLLBACK')
-    throw err
-  }
-}
-
-export async function handleNoRoute (client: pg.PoolClient, msg: any): Promise<void> {
-  const attempts = msg.attempts + 1
-  const failure = failureDetail(
-    msg,
-    attempts,
-    'ROUTE_NOT_FOUND',
-    'No registered target is available for this queue delivery'
-  )
-
-  await client.query('BEGIN')
-  try {
-    if (isMaxAttempts(attempts)) {
-      await lockRunForFailureFinalization(client, msg)
-      const updated = await client.query(
-        `UPDATE workflow_queue_messages
-         SET status = 'dead', attempts = $4, last_failure = $5, dead_at = NOW(),
-             failure_finalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
-         WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
-         RETURNING id`,
-        [msg.id, msg.application_id, msg.attempts, attempts, failure]
-      )
-      if (updated.rows.length > 0) await finalizeFailure(client, msg, failure)
-    } else {
-      const delay = getRetryDelay(attempts)
-      await client.query(
-        `UPDATE workflow_queue_messages
-         SET status = 'failed', attempts = $4, last_failure = $5,
-             next_retry_at = NOW() + make_interval(secs => $6), updated_at = NOW()
-         WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3`,
-        [msg.id, msg.application_id, msg.attempts, attempts, failure, delay / 1000]
-      )
-    }
-    await client.query('COMMIT')
-  } catch (err) {
-    await client.query('ROLLBACK')
-    throw err
-  }
-}
-
-export async function handleDispatchResult (
-  client: pg.PoolClient,
-  msg: any,
-  result: DispatchResult,
-  target?: RegisteredTarget
-): Promise<void> {
-  await client.query('BEGIN')
-  try {
-    if (result.success) {
-      const delivered = await client.query(
-        `UPDATE workflow_queue_messages
-         SET status = 'delivered', delivered_at = NOW(), updated_at = NOW()
-         WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
-         RETURNING id`,
-        [msg.id, msg.application_id, msg.attempts]
-      )
-
-      if (delivered.rows.length > 0 && typeof result.timeoutSeconds === 'number') {
-        const payloadJson = msg.payload_encoding === 'json' ? JSON.stringify(msg.payload) : null
-        const payloadBytes = msg.payload_encoding === 'cbor' ? msg.payload_bytes : null
-        if (result.timeoutSeconds > 0) {
-          await client.query(
-            `INSERT INTO workflow_queue_messages
-               (queue_name, run_id, deployment_version, application_id,
-                payload, payload_bytes, payload_encoding, status, deliver_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, 'deferred', NOW() + make_interval(secs => $8))`,
-            [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
-              payloadJson, payloadBytes, msg.payload_encoding, result.timeoutSeconds]
-          )
-          await client.query("SELECT pg_notify('deferred_messages', '{}')")
-        } else if (result.timeoutSeconds === 0) {
-          await client.query(
-            `INSERT INTO workflow_queue_messages
-               (queue_name, run_id, deployment_version, application_id,
-                payload, payload_bytes, payload_encoding, status)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
-            [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
-              payloadJson, payloadBytes, msg.payload_encoding]
-          )
-          await client.query("SELECT pg_notify('deferred_messages', '{}')")
-        }
-      }
-    } else {
-      const attempts = msg.attempts + 1
-      const error = result.error || { code: 'DISPATCH_ERROR', message: 'Target request failed' }
-      const failure = failureDetail(msg, attempts, error.code, error.message, target, result.statusCode)
-
-      if (isMaxAttempts(attempts)) {
-        await lockRunForFailureFinalization(client, msg)
-        const updated = await client.query(
-          `UPDATE workflow_queue_messages
-           SET status = 'dead', attempts = $4, last_failure = $5, dead_at = NOW(),
-               failure_finalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
-           WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3
-           RETURNING id`,
-          [msg.id, msg.application_id, msg.attempts, attempts, failure]
-        )
-        if (updated.rows.length > 0) await finalizeFailure(client, msg, failure)
-      } else {
-        const delay = getRetryDelay(attempts)
-        await client.query(
-          `UPDATE workflow_queue_messages
-           SET status = 'failed', attempts = $4, last_failure = $5,
-               next_retry_at = NOW() + make_interval(secs => $6), updated_at = NOW()
-           WHERE id = $1 AND application_id = $2 AND status = 'pending' AND attempts = $3`,
-          [msg.id, msg.application_id, msg.attempts, attempts, failure, delay / 1000]
-        )
-      }
-    }
-    await client.query('COMMIT')
-  } catch (err) {
-    await client.query('ROLLBACK')
-    throw err
   }
 }

--- a/packages/workflow/queue/poller.ts
+++ b/packages/workflow/queue/poller.ts
@@ -4,6 +4,7 @@ import { decode, encode } from 'cbor-x'
 import { routeMessage } from './router.ts'
 import { dispatchMessage, type DispatchResult } from './dispatcher.ts'
 import { getRetryDelay, isMaxAttempts, MAX_ATTEMPTS } from './retry.ts'
+import { isStepQueue, isWorkflowQueue, workflowNameFromQueue, workflowQueueNameLike } from './names.ts'
 
 // How often delivered-but-unacknowledged messages are reclaimed.
 const RECLAIM_CHECK_INTERVAL = 60_000
@@ -140,7 +141,7 @@ async function ensureRunForWorkflowDelivery (client: pg.PoolClient, msg: any): P
   const runInput = payload?.runInput
   const workflowName = typeof runInput?.workflowName === 'string'
     ? runInput.workflowName
-    : msg.queue_name.slice('__wkf_workflow_'.length)
+    : workflowNameFromQueue(msg.queue_name)
   const deploymentId = typeof runInput?.deploymentId === 'string'
     ? runInput.deploymentId
     : msg.deployment_version
@@ -198,7 +199,7 @@ async function failBackgroundStep (client: pg.PoolClient, msg: any, failure: Fai
        (queue_name, run_id, deployment_version, application_id,
         payload, payload_bytes, payload_encoding, status)
      VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')`,
-    [`__wkf_workflow_${step.rows[0].workflow_name}`, msg.run_id, msg.deployment_version,
+    [workflowQueueNameLike(msg.queue_name, step.rows[0].workflow_name), msg.run_id, msg.deployment_version,
       msg.application_id, payloadJson, payloadBytes, msg.payload_encoding]
   )
   await client.query("SELECT pg_notify('deferred_messages', '{}')")
@@ -209,16 +210,16 @@ async function finalizeFailure (client: pg.PoolClient, msg: any, failure: Failur
   // v5 dispatches background steps through the workflow queue, while v4 uses
   // a dedicated step queue. The payload is the authoritative discriminator.
   if (await failBackgroundStep(client, msg, failure)) return
-  if (msg.queue_name.startsWith('__wkf_workflow_')) {
+  if (isWorkflowQueue(msg.queue_name)) {
     await failRun(client, msg, failure)
-  } else if (msg.queue_name.startsWith('__wkf_step_')) {
+  } else if (isStepQueue(msg.queue_name)) {
     await failRun(client, msg, failure)
   }
 }
 
 async function lockRunForFailureFinalization (client: pg.PoolClient, msg: any): Promise<void> {
   if (!msg.run_id) return
-  if (msg.queue_name.startsWith('__wkf_workflow_')) await ensureRunForWorkflowDelivery(client, msg)
+  if (isWorkflowQueue(msg.queue_name)) await ensureRunForWorkflowDelivery(client, msg)
   await client.query(
     'SELECT id FROM workflow_runs WHERE id = $1 AND application_id = $2 FOR UPDATE',
     [msg.run_id, msg.application_id]

--- a/packages/workflow/queue/router.ts
+++ b/packages/workflow/queue/router.ts
@@ -1,4 +1,5 @@
 import type pg from 'pg'
+import { isStepQueue, isWorkflowQueue } from './names.ts'
 
 export interface RouteResult {
   url: string
@@ -31,10 +32,11 @@ export async function routeMessage (
 
   if (registrations.rows.length === 0) return null
 
-  const queueMatch = queueName.match(/^__(?:[a-z][a-z0-9]*_)?wkf_(workflow|step)_.+$/)
-  const urlField = queueMatch?.[1] === 'step'
+  // Same grammar as the rest of the service, from ./names.ts, so routing and
+  // failure finalization cannot drift apart on what counts as a workflow queue.
+  const urlField = isStepQueue(queueName)
     ? 'step_url'
-    : queueMatch?.[1] === 'workflow' ? 'workflow_url' : 'webhook_url'
+    : isWorkflowQueue(queueName) ? 'workflow_url' : 'webhook_url'
   const urls = [...new Set(registrations.rows.map(registration => registration[urlField]))]
   const url = urls[Math.floor(Math.random() * urls.length)]
 

--- a/packages/workflow/queue/store.ts
+++ b/packages/workflow/queue/store.ts
@@ -1,0 +1,115 @@
+// The durable record of every queue message.
+//
+// Always Postgres, whatever carries the bytes. Scheduling, dedupe, status,
+// attempt counts and dead letters live here because they are workflow
+// semantics, not broker operations: a sleep() can outlive any broker's delay
+// ceiling, the dead-letter admin API has to work the same regardless of
+// transport, and dead-lettering a message has to commit in the same
+// transaction as failing the run it belongs to.
+//
+// Keeping these out of the transport contract is deliberate. A Redis or SQS
+// backend implements BrokerTransport (./transport.ts) and nothing here, so it
+// never has to grow a notion of a run, an attempt ceiling, or a finalizer.
+
+import type { FailureDetail } from './delivery.ts'
+
+export type MessageId = number | string
+
+// The shape the rest of the service reads. Snake_case because delivery.ts, the
+// dispatcher and the dead-letter API already speak it.
+export interface QueueMessage {
+  id: MessageId
+  application_id: number
+  queue_name: string
+  run_id: string | null
+  deployment_version: string
+  payload: unknown
+  payload_bytes: Buffer | null
+  payload_encoding: 'json' | 'cbor'
+  attempts: number
+  last_failure?: FailureDetail | null
+}
+
+export interface EnqueueRequest {
+  queueName: string
+  applicationId: number
+  runId: string
+  deploymentVersion: string
+  payload: unknown
+  payloadBytes: Buffer | null
+  payloadEncoding: 'json' | 'cbor'
+  idempotencyKey?: string | null
+  delaySeconds?: number
+}
+
+// The workflow-domain half of a terminal failure, in two phases so a store can
+// preserve lock ordering: `lock` runs before the message row is updated (it
+// takes the run row, which is the order the queue has always used and which
+// keeps concurrent finalizations from deadlocking), `finalize` runs after, and
+// only when this caller actually won the update.
+export interface FailureFinalizer {
+  lock (client: any, msg: QueueMessage): Promise<void>
+  finalize (client: any, msg: QueueMessage, failure: FailureDetail): Promise<void>
+}
+
+// One entry the outbox relay still has to hand to a remote broker. Empty for
+// the Postgres transport, where the row and its publication commit together.
+export interface OutboxEntry {
+  messageId: MessageId
+  queueName: string
+  payload: unknown
+  payloadBytes: Buffer | null
+  payloadEncoding: 'json' | 'cbor'
+}
+
+export interface QueueStore {
+  enqueue (req: EnqueueRequest): Promise<{ messageId: MessageId, ready: boolean }>
+
+  // Candidate messages that are ready to run. Returns ids only: whether a
+  // message may actually be dispatched is decided by claimForDispatch.
+  readyMessageIds (limit: number, excludeIds: MessageId[]): Promise<MessageId[]>
+
+  // The redelivery gate, and the real lease. Compare-and-set ready -> delivered.
+  // Returns null when the message is no longer dispatchable (already delivered,
+  // dead, or failed), which is what makes a duplicate broker delivery harmless:
+  // it can never reach the workflow handler.
+  claimForDispatch (messageId: MessageId): Promise<QueueMessage | null>
+
+  // Delivery succeeded. Must move the message to a terminal state: a claimed
+  // message sits in 'delivered' and reclaimExpired treats anything still there
+  // past the visibility timeout as an executor that died, so a success left in
+  // 'delivered' would be redispatched 15 minutes later against a live run.
+  // `continuation` re-publishes the same payload when the handler asked to be
+  // re-invoked (the 425 retryAfter path); 0 means now.
+  ack (msg: QueueMessage, continuation?: { delaySeconds: number }): Promise<void>
+
+  // Undo a claim whose dispatch task threw before recording any outcome, so
+  // the message is immediately claimable again rather than waiting on
+  // reclaimExpired. Must be called before releasing the transport lease.
+  releaseClaim (msg: QueueMessage): Promise<void>
+
+  scheduleRetry (msg: QueueMessage, delayMs: number, failure: FailureDetail): Promise<void>
+  deadLetter (msg: QueueMessage, failure: FailureDetail, f: FailureFinalizer): Promise<void>
+
+  // Deferred and retry-due messages that are now ready.
+  promoteDue (): Promise<void>
+  nextWakeupMs (): Promise<number | null>
+
+  // Messages past the retry ceiling, awaiting finalization.
+  claimExhausted (limit: number): Promise<QueueMessage[]>
+  finalizeExhausted (msg: QueueMessage, f: FailureFinalizer): Promise<void>
+
+  // Redeliver messages whose consumer took the lease and never reported back.
+  reclaimExpired (): Promise<number>
+
+  // Outbox: committed but not yet handed to the broker. See
+  // QUEUE-PLUGGABILITY.md, "The dual write, and the outbox that resolves it".
+  takeUnpublished (limit: number): Promise<OutboxEntry[]>
+  markPublished (messageId: MessageId): Promise<void>
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    queueStore: QueueStore
+  }
+}

--- a/packages/workflow/queue/stores/postgres.ts
+++ b/packages/workflow/queue/stores/postgres.ts
@@ -1,0 +1,342 @@
+// The Postgres QueueStore: the default, and the only store there is.
+//
+// Every transport uses this. What varies is only who carries a ready message to
+// a consumer (see ../transport.ts), never where its durable state lives.
+//
+// It is also the only store that can keep a terminal failure atomic:
+// dead-lettering a message and failing the run it belongs to commit together,
+// so a run is never left running against a message nobody will retry. With a
+// remote transport the broker ack happens after that commit, and a lost ack is
+// harmless because claimForDispatch refuses the redelivery.
+
+import type pg from 'pg'
+import { MAX_ATTEMPTS } from '../retry.ts'
+import { failRun, failureDetail, lockRunForFailureFinalization, type FailureDetail } from '../delivery.ts'
+import type {
+  EnqueueRequest, MessageId, OutboxEntry, QueueMessage, QueueStore,
+} from '../store.ts'
+
+const DEFERRED_CHANNEL = 'deferred_messages'
+const DEFAULT_VISIBILITY_TIMEOUT_S = 900
+const VISIBILITY_TIMEOUT_S = Number(process.env.WF_DELIVERY_VISIBILITY_TIMEOUT_S) > 0
+  ? Number(process.env.WF_DELIVERY_VISIBILITY_TIMEOUT_S)
+  : DEFAULT_VISIBILITY_TIMEOUT_S
+
+export function createPostgresQueueStore (
+  pool: pg.Pool, log: any, transportName: string
+): QueueStore {
+  async function inTransaction<T> (fn: (client: pg.PoolClient) => Promise<T>): Promise<T> {
+    const client = await pool.connect()
+    try {
+      await client.query('BEGIN')
+      const out = await fn(client)
+      await client.query('COMMIT')
+      return out
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {})
+      throw err
+    } finally {
+      client.release()
+    }
+  }
+
+  async function notify (): Promise<void> {
+    await pool.query(`SELECT pg_notify('${DEFERRED_CHANNEL}', '{}')`)
+  }
+
+  return {
+    async enqueue (req: EnqueueRequest) {
+      const delaySeconds = req.delaySeconds || 0
+      const deferred = delaySeconds > 0
+      const result = await pool.query(
+        `INSERT INTO workflow_queue_messages
+           (idempotency_key, queue_name, run_id, deployment_version, application_id,
+            payload, payload_bytes, payload_encoding, status, deliver_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
+                 CASE WHEN $10::int > 0 THEN NOW() + make_interval(secs => $10::int) ELSE NULL END)
+         RETURNING id`,
+        [req.idempotencyKey || null, req.queueName, req.runId, req.deploymentVersion,
+          req.applicationId, req.payload, req.payloadBytes, req.payloadEncoding,
+          deferred ? 'deferred' : 'pending', delaySeconds]
+      )
+      await notify()
+      return { messageId: result.rows[0].id as MessageId, ready: !deferred }
+    },
+
+    async readyMessageIds (limit, excludeIds) {
+      // Only messages the transport has actually been handed. With an inline
+      // transport that is every committed row; with a relay it excludes rows
+      // still waiting to be published.
+      const { rows } = await pool.query(
+        `SELECT id FROM workflow_queue_messages
+         WHERE status = 'pending' AND published_at IS NOT NULL
+           AND NOT (id = ANY($1::bigint[]))
+         ORDER BY created_at ASC
+         LIMIT $2`,
+        [excludeIds, limit]
+      )
+      return rows.map(r => r.id as MessageId)
+    },
+
+    async claimForDispatch (messageId) {
+      // The gate. A message may be dispatched exactly once per attempt, and only
+      // from 'pending'. A redelivery of something already delivered, dead or
+      // failed loses the CAS and is dropped before it can reach the handler.
+      const { rows } = await pool.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'delivered', delivered_at = NOW(), updated_at = NOW()
+         WHERE id = $1 AND status = 'pending'
+         RETURNING *`,
+        [messageId]
+      )
+      return (rows[0] as QueueMessage) ?? null
+    },
+
+    async ack (msg, continuation) {
+      // One transaction, deliberately. Marking the delivery terminal and
+      // writing the continuation it asked for have to commit together: if the
+      // ack landed and the continuation did not, the run would be waiting on a
+      // message that no longer exists and nothing would redeliver it, because
+      // 'acked' is exactly the state reclaimExpired skips.
+      await inTransaction(async (client) => {
+        await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'acked', acked_at = NOW(), updated_at = NOW()
+           WHERE id = $1 AND application_id = $2 AND status = 'delivered'`,
+          [msg.id, msg.application_id]
+        )
+        if (!continuation) return
+
+        const { delaySeconds } = continuation
+        const payloadJson = msg.payload_encoding === 'json' ? JSON.stringify(msg.payload) : null
+        const payloadBytes = msg.payload_encoding === 'cbor' ? msg.payload_bytes : null
+        await client.query(
+          `INSERT INTO workflow_queue_messages
+             (queue_name, run_id, deployment_version, application_id,
+              payload, payload_bytes, payload_encoding, status, deliver_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
+                   CASE WHEN $9::int > 0 THEN NOW() + make_interval(secs => $9::int) ELSE NULL END)`,
+          [msg.queue_name, msg.run_id, msg.deployment_version, msg.application_id,
+            payloadJson, payloadBytes, msg.payload_encoding,
+            delaySeconds > 0 ? 'deferred' : 'pending', delaySeconds]
+        )
+        await client.query(`SELECT pg_notify('${DEFERRED_CHANNEL}', '{}')`)
+      })
+    },
+
+    async releaseClaim (msg) {
+      // The dispatch task threw without recording an outcome, so the claim has
+      // to go back before the transport re-offers the message: a redelivery
+      // would otherwise lose claimForDispatch (the row is still 'delivered')
+      // and be acked without ever executing, leaving recovery to the
+      // 15-minute reclaimer. Attempts are untouched, since no delivery
+      // actually happened.
+      await pool.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'pending', delivered_at = NULL, updated_at = NOW()
+         WHERE id = $1 AND application_id = $2 AND status = 'delivered'`,
+        [msg.id, msg.application_id]
+      )
+    },
+
+    async scheduleRetry (msg, delayMs, failure) {
+      await pool.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'failed', attempts = $4, last_failure = $5,
+             next_retry_at = NOW() + make_interval(secs => $6), updated_at = NOW()
+         WHERE id = $1 AND application_id = $2 AND attempts = $3`,
+        [msg.id, msg.application_id, msg.attempts, msg.attempts + 1, failure, delayMs / 1000]
+      )
+    },
+
+    async deadLetter (msg, failure, f) {
+      await inTransaction(async (client) => {
+        await f.lock(client, msg)
+        const updated = await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'dead', attempts = $4, last_failure = $5, dead_at = NOW(),
+               failure_finalized_at = NOW(), next_retry_at = NULL, updated_at = NOW()
+           WHERE id = $1 AND application_id = $2 AND attempts = $3 AND status != 'dead'
+           RETURNING id`,
+          [msg.id, msg.application_id, msg.attempts, msg.attempts + 1, failure]
+        )
+        if (updated.rows.length > 0) await f.finalize(client, msg, failure)
+      })
+    },
+
+    async promoteDue () {
+      await pool.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'pending', updated_at = NOW(), published_at = NULL, published_to = NULL
+         WHERE status = 'deferred' AND deliver_at <= NOW()`
+      )
+      await pool.query(
+        `UPDATE workflow_queue_messages
+         SET status = 'pending', updated_at = NOW(), published_at = NULL, published_to = NULL
+         WHERE status = 'failed' AND next_retry_at <= NOW() AND attempts < $1`,
+        [MAX_ATTEMPTS]
+      )
+    },
+
+    async nextWakeupMs () {
+      const result = await pool.query(
+        `SELECT EXTRACT(EPOCH FROM (MIN(next_time) - NOW())) AS secs
+         FROM (
+           SELECT deliver_at AS next_time FROM workflow_queue_messages
+             WHERE status = 'deferred' AND deliver_at > NOW()
+           UNION ALL
+           SELECT next_retry_at AS next_time FROM workflow_queue_messages
+             WHERE status = 'failed' AND next_retry_at > NOW() AND attempts < $1
+         ) t`,
+        [MAX_ATTEMPTS]
+      )
+      const secs = result.rows[0]?.secs
+      if (secs === null || secs === undefined) return null
+      return Math.max(Math.ceil(Number(secs) * 1000), 50)
+    },
+
+    async claimExhausted (limit) {
+      const { rows } = await pool.query(
+        `SELECT * FROM workflow_queue_messages
+         WHERE status = 'failed' AND attempts >= $1
+         ORDER BY created_at ASC
+         LIMIT $2`,
+        [MAX_ATTEMPTS, limit]
+      )
+      return rows as QueueMessage[]
+    },
+
+    async finalizeExhausted (msg, f) {
+      const failure: FailureDetail = msg.last_failure || {
+        code: 'RETRY_EXHAUSTED',
+        message: 'Queue delivery exhausted all retry attempts',
+        at: new Date().toISOString(),
+        attempt: msg.attempts,
+        target: { queueName: msg.queue_name, deploymentVersion: msg.deployment_version },
+      }
+      await inTransaction(async (client) => {
+        await f.lock(client, msg)
+        const updated = await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'dead', last_failure = $4, dead_at = NOW(), failure_finalized_at = NOW(),
+               next_retry_at = NULL, updated_at = NOW()
+           WHERE id = $1 AND application_id = $2 AND status = 'failed' AND attempts = $3
+           RETURNING id`,
+          [msg.id, msg.application_id, msg.attempts, failure]
+        )
+        if (updated.rows.length > 0) await f.finalize(client, msg, failure)
+      })
+    },
+
+    async reclaimExpired () {
+      const client = await pool.connect()
+      try {
+        return await reclaimExpiredDeliveries(client, log, VISIBILITY_TIMEOUT_S)
+      } finally {
+        client.release()
+      }
+    },
+
+    async takeUnpublished (limit) {
+      // Not yet handed over at all, or handed to a different transport than the
+      // one running now. The second case is a driver change: those rows were
+      // marked published against a broker that no longer carries them, so they
+      // have to go again or they are never delivered.
+      const { rows } = await pool.query(
+        `SELECT id, queue_name, payload, payload_bytes, payload_encoding
+         FROM workflow_queue_messages
+         WHERE status = 'pending'
+           AND (published_at IS NULL OR published_to IS DISTINCT FROM $2)
+         ORDER BY created_at ASC
+         LIMIT $1`,
+        [limit, transportName]
+      )
+      return rows.map(r => ({
+        messageId: r.id as MessageId,
+        queueName: r.queue_name,
+        payload: r.payload,
+        payloadBytes: r.payload_bytes,
+        payloadEncoding: r.payload_encoding,
+      })) as OutboxEntry[]
+    },
+
+    async markPublished (messageId) {
+      await pool.query(
+        'UPDATE workflow_queue_messages SET published_at = NOW(), published_to = $2 WHERE id = $1',
+        [messageId, transportName]
+      )
+    },
+  }
+}
+
+// Exported for direct testing; the store calls it through reclaimExpired().
+export async function reclaimExpiredDeliveries (
+  client: pg.PoolClient,
+  log: any,
+  visibilityTimeoutS: number = VISIBILITY_TIMEOUT_S
+): Promise<number> {
+  try {
+    // Under the retry ceiling: hand it back to the poller for another attempt.
+    const reclaimed = await client.query(
+      `UPDATE workflow_queue_messages m
+       SET status = 'pending', attempts = m.attempts + 1,
+           delivered_at = NULL, updated_at = NOW(), published_at = NULL, published_to = NULL
+       FROM workflow_runs r
+       WHERE m.run_id = r.id
+         AND m.status = 'delivered'
+         AND m.delivered_at < NOW() - make_interval(secs => $1)
+         AND r.status IN ('pending', 'running')
+         AND m.attempts < $2
+       RETURNING m.id, m.run_id, m.queue_name, m.attempts`,
+      [visibilityTimeoutS, MAX_ATTEMPTS]
+    )
+
+    if (reclaimed.rows.length > 0) {
+      log.warn(
+        { count: reclaimed.rows.length, visibilityTimeoutS },
+        'Reclaimed delivered messages whose executor never reported back'
+      )
+    }
+
+    // At the ceiling there is nothing left to retry, so finalize rather than
+    // leave the run running forever.
+    const exhausted = await client.query(
+      `SELECT m.id, m.run_id, m.application_id, m.queue_name, m.deployment_version, m.attempts
+       FROM workflow_queue_messages m
+       JOIN workflow_runs r ON r.id = m.run_id
+       WHERE m.status = 'delivered'
+         AND m.delivered_at < NOW() - make_interval(secs => $1)
+         AND r.status IN ('pending', 'running')
+         AND m.attempts >= $2
+       LIMIT 10`,
+      [visibilityTimeoutS, MAX_ATTEMPTS]
+    )
+
+    for (const msg of exhausted.rows) {
+      await client.query('BEGIN')
+      try {
+        const failure = failureDetail(
+          msg, msg.attempts, 'DELIVERY_TIMEOUT',
+          `Message delivered but never acknowledged within ${visibilityTimeoutS}s, and retries are exhausted`
+        )
+        await lockRunForFailureFinalization(client, msg)
+        await client.query(
+          `UPDATE workflow_queue_messages
+           SET status = 'dead', last_failure = $3, dead_at = NOW(),
+               failure_finalized_at = NOW(), updated_at = NOW()
+           WHERE id = $1 AND application_id = $2 AND status = 'delivered'`,
+          [msg.id, msg.application_id, failure]
+        )
+        await failRun(client, msg, failure)
+        await client.query('COMMIT')
+      } catch (err) {
+        await client.query('ROLLBACK')
+        throw err
+      }
+    }
+    return reclaimed.rows.length
+  } catch (err) {
+    log.error({ err }, 'Delivery reclaim error')
+    return 0
+  }
+}

--- a/packages/workflow/queue/transport.ts
+++ b/packages/workflow/queue/transport.ts
@@ -1,0 +1,51 @@
+// What actually carries a ready message to a consumer.
+//
+// This is the pluggable half, and the whole of it: a new backend implements
+// these methods and nothing else. Nothing here knows what a run, an attempt
+// ceiling or a deployment version is, because none of that is a broker's job.
+// Scheduling, dedupe, status and dead letters stay in the QueueStore
+// (./store.ts) for every transport.
+//
+// Delivery is at-least-once by construction. A transport may hand the same
+// message over twice (a lost ack, an outbox relay that republished after
+// crashing); QueueStore.claimForDispatch is the gate that makes that safe, so a
+// transport is never required to deduplicate.
+
+import type { MessageId } from './store.ts'
+
+export interface LeasedMessage {
+  messageId: MessageId
+  // Opaque handle for acking this particular delivery. For a broker that has no
+  // separate concept, the message id itself is a fine lease id.
+  leaseId: string
+}
+
+export interface BrokerTransport {
+  readonly name: string
+
+  // Hand a committed message to the broker. Called by the outbox relay, never
+  // in the enqueue transaction: the store commits first, then this publishes.
+  // Must be idempotent on messageId, since the relay retries.
+  publish (messageId: MessageId, entry: { queueName: string, payload: unknown, payloadBytes: Buffer | null, payloadEncoding: 'json' | 'cbor' }): Promise<void>
+
+  // Take up to `max` messages for this consumer.
+  receive (max: number): Promise<LeasedMessage[]>
+
+  // This delivery is settled: its fate is recorded in the store, and the
+  // broker's copy can go.
+  ack (leaseId: string): Promise<void>
+
+  // This delivery was NOT settled -- the consumer threw before recording an
+  // outcome -- so the message must become available again. A broker with a
+  // visibility timeout could reach the same state by doing nothing, but a
+  // transport that tracks leases in memory has to be told, or the message is
+  // stranded for the life of the process.
+  release (leaseId: string): Promise<void>
+
+  // Wake the poll loop when work arrives, where the transport can push. A
+  // transport with no push support may return without subscribing; the poller
+  // keeps its safety-net interval either way.
+  subscribe (onWake: () => void): Promise<void>
+
+  close (): Promise<void>
+}

--- a/packages/workflow/queue/transports/postgres.ts
+++ b/packages/workflow/queue/transports/postgres.ts
@@ -1,0 +1,93 @@
+// The default transport: Postgres carries the messages too.
+//
+// Degenerate by design. Store and transport are the same system here, so
+// publish is a no-op and receive reads the ready ids the store already has.
+// The message's real lease is the store's claimForDispatch, which is true for
+// every transport; what this tracks in `leased` is only which ids have been
+// handed to a dispatch task in this process, so one poll cycle does not hand
+// the same id out twice.
+//
+// It exists so the boundary in ../transport.ts is honest rather than
+// hypothetical: everything a remote broker would have to do is already routed
+// through these five methods, and nothing else in the service reaches past
+// them.
+
+import type pg from 'pg'
+import type { BrokerTransport, LeasedMessage } from '../transport.ts'
+import type { MessageId, QueueStore } from '../store.ts'
+
+const DEFERRED_CHANNEL = 'deferred_messages'
+
+export function createPostgresTransport (
+  store: QueueStore, connectionString: string, log: any
+): BrokerTransport {
+  let listenClient: pg.Client | null = null
+  let stopped = false
+  // Ids handed out by receive() and not yet acked. Postgres has no visibility
+  // timeout of its own at this layer, so this keeps one poll cycle from handing
+  // the same id to two dispatch tasks; a crash simply forgets it, and the
+  // store's reclaimExpired covers the message.
+  const leased = new Set<MessageId>()
+
+  function forget (leaseId: string): void {
+    leased.delete(leaseId)
+    const asNumber = Number(leaseId)
+    if (!Number.isNaN(asNumber)) leased.delete(asNumber)
+  }
+
+  return {
+    name: 'postgres',
+
+    async publish () {
+      // Nothing to hand over: the store and the transport are the same system.
+      // The relay still calls this and then stamps published_at, so every
+      // producer goes through one path and none can be forgotten.
+    },
+
+    async receive (max: number): Promise<LeasedMessage[]> {
+      const ids = await store.readyMessageIds(max, Array.from(leased))
+      for (const id of ids) leased.add(id)
+      return ids.map(messageId => ({ messageId, leaseId: String(messageId) }))
+    },
+
+    async ack (leaseId: string) {
+      forget(leaseId)
+    },
+
+    async release (leaseId: string) {
+      // Postgres has no visibility timeout at this layer, so a lease that is
+      // never released is excluded from receive() for the life of the process,
+      // even after the store hands the row back to 'pending'.
+      forget(leaseId)
+    },
+
+    async subscribe (onWake: () => void) {
+      const pgMod = (await import('pg')).default
+      const connect = (): void => {
+        listenClient = new pgMod.Client({ connectionString })
+        listenClient.on('error', (err: any) => {
+          log.error({ err }, 'LISTEN connection error')
+          if (!stopped) setTimeout(connect, 1000)
+        })
+        listenClient.connect()
+          .then(() => listenClient!.query(`LISTEN "${DEFERRED_CHANNEL}"`))
+          .then(() => { log.info({ channel: DEFERRED_CHANNEL }, 'Listening to notification channel') })
+          .catch((err: any) => {
+            log.error({ err }, 'Failed to setup LISTEN connection')
+            if (!stopped) setTimeout(connect, 1000)
+          })
+        listenClient.on('notification', () => onWake())
+      }
+      connect()
+    },
+
+    async close () {
+      stopped = true
+      leased.clear()
+      if (listenClient) {
+        listenClient.end().catch(() => {})
+        listenClient = null
+      }
+    },
+  }
+}

--- a/packages/workflow/test/delivery-reclaim.test.ts
+++ b/packages/workflow/test/delivery-reclaim.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { reclaimExpiredDeliveries } from '../queue/poller.ts'
+import { reclaimExpiredDeliveries } from '../queue/stores/postgres.ts'
 import { setupTest, teardownTest, type TestContext } from './helper.ts'
 
 const silentLog = { warn () {}, error () {}, info () {} }

--- a/packages/workflow/test/poller.test.ts
+++ b/packages/workflow/test/poller.test.ts
@@ -2,7 +2,12 @@ import { randomUUID } from 'node:crypto'
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { decode, encode } from 'cbor-x'
-import { handleDispatchResult, handleNoRoute } from '../queue/poller.ts'
+import { onDispatchResult, onNoRoute } from '../queue/poller.ts'
+import { createPostgresQueueStore } from '../queue/stores/postgres.ts'
+
+const silentLog = { info () {}, warn () {}, error () {} }
+const makeStore = (ctx: TestContext) =>
+  createPostgresQueueStore(ctx.app.pg, silentLog, 'postgres')
 import { setupTest, teardownTest, type TestContext } from './helper.ts'
 
 describe('poller result handling', () => {
@@ -54,21 +59,17 @@ describe('poller result handling', () => {
       [runId, applicationId, JSON.stringify({ runId })]
     )
     const msg = inserted.rows[0]
-    const client = await ctx.app.pg.connect()
-    try {
-      const failure = {
-        success: false,
-        statusCode: 503,
-        error: { code: 'HTTP_503', message: 'Target returned HTTP 503' },
-      }
-      const target = {
-        url: 'https://user:password@example.com/flow?token=secret#fragment',
-      }
-      await handleDispatchResult(client, msg, failure, target)
-      await handleDispatchResult(client, msg, failure, target)
-    } finally {
-      client.release()
+    const store = makeStore(ctx)
+    const failure = {
+      success: false,
+      statusCode: 503,
+      error: { code: 'HTTP_503', message: 'Target returned HTTP 503' },
     }
+    const target = {
+      url: 'https://user:password@example.com/flow?token=secret#fragment',
+    }
+    await onDispatchResult(store, msg, failure, target)
+    await onDispatchResult(store, msg, failure, target)
 
     const message = (await ctx.app.pg.query(
       `SELECT status, attempts, last_failure, dead_at, failure_finalized_at
@@ -126,16 +127,11 @@ describe('poller result handling', () => {
             encoding === 'cbor' ? Buffer.from(encode(payload)) : null,
             encoding]
         )
-        const client = await ctx.app.pg.connect()
-        try {
-          await handleDispatchResult(client, inserted.rows[0], {
-            success: false,
-            statusCode: 0,
-            error: { code: 'ECONNRESET', message: 'Target connection was reset' },
-          })
-        } finally {
-          client.release()
-        }
+        await onDispatchResult(makeStore(ctx), inserted.rows[0], {
+          success: false,
+          statusCode: 0,
+          error: { code: 'ECONNRESET', message: 'Target connection was reset' },
+        })
 
         const step = (await ctx.app.pg.query(
           'SELECT status FROM workflow_steps WHERE run_id = $1 AND correlation_id = $2',
@@ -176,12 +172,7 @@ describe('poller result handling', () => {
        RETURNING *`,
       [applicationId]
     )
-    const client = await ctx.app.pg.connect()
-    try {
-      await handleNoRoute(client, inserted.rows[0])
-    } finally {
-      client.release()
-    }
+    await onNoRoute(makeStore(ctx), inserted.rows[0])
     const row = (await ctx.app.pg.query(
       'SELECT status, attempts, last_failure, updated_at FROM workflow_queue_messages WHERE id = $1',
       [inserted.rows[0].id]
@@ -192,7 +183,7 @@ describe('poller result handling', () => {
     assert.ok(row.updated_at)
   })
 
-  it('re-enqueues a successful continuation only when delivery wins the predicate', async () => {
+  it('re-enqueues a successful continuation once, gated by claimForDispatch', async () => {
     const runId = await createRun('successful-continuation')
     const inserted = await ctx.app.pg.query(
       `INSERT INTO workflow_queue_messages
@@ -201,19 +192,22 @@ describe('poller result handling', () => {
        RETURNING *`,
       [runId, applicationId, JSON.stringify({ runId })]
     )
-    const client = await ctx.app.pg.connect()
-    try {
-      const result = { success: true, statusCode: 200, timeoutSeconds: 0 }
-      await handleDispatchResult(client, inserted.rows[0], result)
-      await handleDispatchResult(client, inserted.rows[0], result)
-    } finally {
-      client.release()
-    }
+    const store = makeStore(ctx)
+    const result = { success: true, statusCode: 200, timeoutSeconds: 0 }
+    // The gate, not the handler, is what makes this exactly-once: a second
+    // claim of the same message returns null, so the continuation is written
+    // once however many times the broker redelivers it.
+    const claimed = await store.claimForDispatch(inserted.rows[0].id)
+    assert.ok(claimed, 'first claim wins')
+    assert.equal(await store.claimForDispatch(inserted.rows[0].id), null, 'second claim is refused')
+    await onDispatchResult(store, claimed!, result)
 
+    // 'acked', not 'delivered': a completed delivery has to leave the state
+    // reclaimExpired treats as an abandoned one.
     assert.equal((await ctx.app.pg.query(
       'SELECT status FROM workflow_queue_messages WHERE id = $1',
       [inserted.rows[0].id]
-    )).rows[0].status, 'delivered')
+    )).rows[0].status, 'acked')
     const continuations = await ctx.app.pg.query(
       `SELECT id FROM workflow_queue_messages
        WHERE run_id = $1 AND queue_name = '__wkf_workflow_successful-continuation'

--- a/packages/workflow/test/queue-conformance.test.ts
+++ b/packages/workflow/test/queue-conformance.test.ts
@@ -1,0 +1,154 @@
+// Contract every queue backend must satisfy.
+//
+// Written against the QueueStore + BrokerTransport interfaces rather than any
+// one implementation, so a second transport (Redis, SQS) is wired in by adding
+// a case to BACKENDS and has to earn the same guarantees. Today only the
+// Postgres backend exists, which is the point: these are the assertions that
+// tell us whether the next one is correct.
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomBytes } from 'node:crypto'
+import { setupTest, teardownTest, type TestContext } from './helper.ts'
+import { createQueueBackend } from '../queue/factory.ts'
+import { failureFinalizer } from '../queue/poller.ts'
+import type { QueueStore } from '../queue/store.ts'
+import type { BrokerTransport } from '../queue/transport.ts'
+
+const silentLog = { info () {}, warn () {}, error () {} }
+
+const BACKENDS = ['postgres']
+
+for (const driver of BACKENDS) {
+  describe(`queue backend conformance: ${driver}`, () => {
+    let ctx: TestContext
+    let store: QueueStore
+    let transport: BrokerTransport
+    let applicationId: number
+
+    before(async () => {
+      ctx = await setupTest()
+      const backend = createQueueBackend(ctx.app.pg, ctx.app.pgConnectionString, silentLog, driver)
+      store = backend.store
+      transport = backend.transport
+      const app = await ctx.app.pg.query(
+        'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+      )
+      applicationId = app.rows[0].id
+    })
+
+    after(async () => {
+      await transport.close()
+      await teardownTest(ctx)
+    })
+
+    // What the poller does each cycle before receiving: hand committed messages
+    // to the transport. For Postgres publish is a no-op and this only stamps
+    // published_at, but it runs for every backend so no producer can bypass it.
+    async function relay (): Promise<void> {
+      for (const entry of await store.takeUnpublished(100)) {
+        await transport.publish(entry.messageId, entry)
+        await store.markPublished(entry.messageId)
+      }
+    }
+
+    const enqueue = (over: Record<string, unknown> = {}) => store.enqueue({
+      queueName: `__wkf_workflow_conformance-${randomBytes(4).toString('hex')}`,
+      applicationId,
+      runId: '',
+      deploymentVersion: 'v1',
+      payload: JSON.stringify({ hello: 'world' }),
+      payloadBytes: null,
+      payloadEncoding: 'json',
+      ...over,
+    } as any)
+
+    it('makes an enqueued message receivable once relayed', async () => {
+      const { messageId, ready } = await enqueue()
+      assert.equal(ready, true)
+      await relay()
+      const received = await transport.receive(50)
+      assert.ok(received.some(m => String(m.messageId) === String(messageId)))
+    })
+
+    it('does not offer a deferred message before it is due', async () => {
+      const { messageId, ready } = await enqueue({ delaySeconds: 3600 })
+      assert.equal(ready, false)
+      await relay()
+      const received = await transport.receive(50)
+      assert.ok(!received.some(m => String(m.messageId) === String(messageId)))
+    })
+
+    it('claims a message exactly once', async () => {
+      const { messageId } = await enqueue()
+      const first = await store.claimForDispatch(messageId)
+      assert.ok(first, 'first claim wins')
+      assert.equal(first!.attempts, 0)
+      // The gate: whatever the transport does, a second claim is refused.
+      assert.equal(await store.claimForDispatch(messageId), null)
+    })
+
+    it('reports the next wake-up for a deferred message', async () => {
+      await enqueue({ delaySeconds: 60 })
+      const ms = await store.nextWakeupMs()
+      assert.ok(ms !== null && ms > 0 && ms <= 60_000, `expected a due time, got ${ms}`)
+    })
+
+    it('returns a retried message to ready once its backoff elapses', async () => {
+      const { messageId } = await enqueue()
+      const msg = await store.claimForDispatch(messageId)
+      await store.scheduleRetry(msg!, 0, {
+        code: 'HTTP_503',
+        message: 'boom',
+        at: new Date().toISOString(),
+        attempt: 1,
+        target: { queueName: msg!.queue_name, deploymentVersion: 'v1' },
+      })
+      await store.promoteDue()
+      const again = await store.claimForDispatch(messageId)
+      assert.ok(again, 'a retried message becomes claimable again')
+      assert.equal(again!.attempts, 1, 'the retry counted an attempt')
+    })
+
+    it('keeps a message out of the ready set until the relay has published it', async () => {
+      const { messageId } = await enqueue()
+      // Committed but not yet handed to the transport: not offerable yet. This
+      // is what stops a producer that writes a row directly from being marked
+      // published without ever having been sent.
+      assert.ok((await store.takeUnpublished(100)).some(e => String(e.messageId) === String(messageId)))
+      assert.ok(!(await transport.receive(50)).some(m => String(m.messageId) === String(messageId)))
+
+      await relay()
+      assert.ok(!(await store.takeUnpublished(100)).some(e => String(e.messageId) === String(messageId)))
+      assert.ok((await transport.receive(50)).some(m => String(m.messageId) === String(messageId)))
+    })
+
+    it('dead-letters a message and finalizes it in one step', async () => {
+      const runId = `wrun_conf_${randomBytes(6).toString('hex')}`
+      await ctx.app.pg.query(
+        `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, spec_version)
+         VALUES ($1, $2, 'conformance', 'v1', 'running', 7)`,
+        [runId, applicationId]
+      )
+      const { messageId } = await enqueue({ runId, queueName: '__wkf_workflow_conformance' })
+      const msg = await store.claimForDispatch(messageId)
+      await store.deadLetter(msg!, {
+        code: 'HTTP_500',
+        message: 'terminal',
+        at: new Date().toISOString(),
+        attempt: 10,
+        target: { queueName: msg!.queue_name, deploymentVersion: 'v1' },
+      }, failureFinalizer)
+
+      const row = (await ctx.app.pg.query(
+        'SELECT status, dead_at FROM workflow_queue_messages WHERE id = $1', [messageId]
+      )).rows[0]
+      assert.equal(row.status, 'dead')
+      assert.ok(row.dead_at)
+      const run = (await ctx.app.pg.query(
+        'SELECT status FROM workflow_runs WHERE id = $1', [runId]
+      )).rows[0]
+      assert.equal(run.status, 'failed', 'the run is finalized with the dead letter')
+    })
+  })
+}

--- a/packages/workflow/test/queue-redelivery.test.ts
+++ b/packages/workflow/test/queue-redelivery.test.ts
@@ -1,0 +1,378 @@
+// Crash and redelivery behaviour.
+//
+// These are the assertions the design leans on when the transport is remote and
+// the broker can hand the same message over twice: a lost ack, or an outbox
+// relay that republished after crashing. The claim is that a duplicate can
+// never reach the workflow handler, and that a consumer that dies mid-flight
+// gets its message back rather than stranding the run.
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomBytes } from 'node:crypto'
+import { setupTest, teardownTest, type TestContext } from './helper.ts'
+import { createQueueBackend } from '../queue/factory.ts'
+import { failureFinalizer } from '../queue/poller.ts'
+import { reclaimExpiredDeliveries } from '../queue/stores/postgres.ts'
+import type { QueueStore } from '../queue/store.ts'
+import type { BrokerTransport } from '../queue/transport.ts'
+
+const silentLog = { info () {}, warn () {}, error () {} }
+
+describe('queue crash and redelivery', () => {
+  let ctx: TestContext
+  let store: QueueStore
+  let transport: BrokerTransport
+  let applicationId: number
+
+  before(async () => {
+    ctx = await setupTest()
+    const backend = createQueueBackend(ctx.app.pg, ctx.app.pgConnectionString, silentLog, 'postgres')
+    store = backend.store
+    transport = backend.transport
+    const app = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+    )
+    applicationId = app.rows[0].id
+  })
+
+  after(async () => {
+    await transport.close()
+    await teardownTest(ctx)
+  })
+
+  async function seed (): Promise<{ runId: string, messageId: any }> {
+    const runId = `wrun_rd_${randomBytes(6).toString('hex')}`
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, spec_version)
+       VALUES ($1, $2, 'redelivery', 'v1', 'running', 7)`,
+      [runId, applicationId]
+    )
+    const { messageId } = await store.enqueue({
+      queueName: '__wkf_workflow_redelivery',
+      applicationId,
+      runId,
+      deploymentVersion: 'v1',
+      payload: JSON.stringify({ runId }),
+      payloadBytes: null,
+      payloadEncoding: 'json',
+    })
+    return { runId, messageId }
+  }
+
+  it('refuses to re-dispatch a message the broker redelivered after a lost ack', async () => {
+    const { messageId } = await seed()
+    const claimed = await store.claimForDispatch(messageId)
+    assert.ok(claimed)
+
+    // Broker redelivers because the ack never landed. The gate must refuse it,
+    // otherwise the workflow handler would run a second time.
+    assert.equal(await store.claimForDispatch(messageId), null)
+  })
+
+  it('refuses to dispatch a message whose run was already failed', async () => {
+    const { messageId } = await seed()
+    const claimed = await store.claimForDispatch(messageId)
+    await store.deadLetter(claimed!, {
+      code: 'HTTP_500',
+      message: 'terminal',
+      at: new Date().toISOString(),
+      attempt: 10,
+      target: { queueName: claimed!.queue_name, deploymentVersion: 'v1' },
+    }, failureFinalizer)
+
+    // The ack after the dead letter is what a remote transport can lose. The
+    // redelivery must not reach the handler.
+    assert.equal(await store.claimForDispatch(messageId), null)
+    const row = (await ctx.app.pg.query(
+      'SELECT status FROM workflow_queue_messages WHERE id = $1', [messageId]
+    )).rows[0]
+    assert.equal(row.status, 'dead')
+  })
+
+  it('returns a message whose consumer died mid-dispatch', async () => {
+    const { messageId } = await seed()
+    const claimed = await store.claimForDispatch(messageId)
+    assert.ok(claimed, 'claimed, then the process dies before reporting back')
+
+    // Nothing else reclaims a 'delivered' message: the retry paths only touch
+    // pending, deferred and failed. Age it past the visibility timeout.
+    await ctx.app.pg.query(
+      "UPDATE workflow_queue_messages SET delivered_at = NOW() - interval '20 minutes' WHERE id = $1",
+      [messageId]
+    )
+    const client = await ctx.app.pg.connect()
+    try {
+      assert.equal(await reclaimExpiredDeliveries(client, silentLog, 60), 1)
+    } finally {
+      client.release()
+    }
+
+    const again = await store.claimForDispatch(messageId)
+    assert.ok(again, 'the message is claimable again after reclaim')
+    assert.equal(again!.attempts, 1, 'the lost delivery counted as an attempt')
+  })
+
+  it('leaves an idle run alone: no message outstanding is not a fault', async () => {
+    const { messageId } = await seed()
+    // Delivered and acked long ago; the run is parked on a hook. Reclaim must
+    // not resurrect it, or every long-lived workflow would be redelivered.
+    await store.claimForDispatch(messageId)
+    await ctx.app.pg.query(
+      `UPDATE workflow_queue_messages SET status = 'dead', delivered_at = NOW() - interval '20 minutes'
+       WHERE id = $1`,
+      [messageId]
+    )
+    const client = await ctx.app.pg.connect()
+    try {
+      assert.equal(await reclaimExpiredDeliveries(client, silentLog, 60), 0)
+    } finally {
+      client.release()
+    }
+  })
+
+  it('republishing from the outbox does not duplicate a delivery', async () => {
+    const { messageId } = await seed()
+    // A relay that crashed between publish and markPublished publishes again.
+    // publish() is required to be idempotent on messageId, and the gate covers
+    // the rest: only one claim can ever win.
+    await transport.publish(messageId, {
+      queueName: '__wkf_workflow_redelivery',
+      payload: JSON.stringify({}),
+      payloadBytes: null,
+      payloadEncoding: 'json',
+    })
+    await transport.publish(messageId, {
+      queueName: '__wkf_workflow_redelivery',
+      payload: JSON.stringify({}),
+      payloadBytes: null,
+      payloadEncoding: 'json',
+    })
+    assert.ok(await store.claimForDispatch(messageId))
+    assert.equal(await store.claimForDispatch(messageId), null)
+  })
+})
+
+describe('queue delivery lifecycle', () => {
+  let ctx: TestContext
+  let store: QueueStore
+  let transport: BrokerTransport
+  let applicationId: number
+
+  before(async () => {
+    ctx = await setupTest()
+    const backend = createQueueBackend(ctx.app.pg, ctx.app.pgConnectionString, silentLog, 'postgres')
+    store = backend.store
+    transport = backend.transport
+    const app = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+    )
+    applicationId = app.rows[0].id
+  })
+
+  after(async () => {
+    await transport.close()
+    await teardownTest(ctx)
+  })
+
+  const enqueue = () => store.enqueue({
+    queueName: '__wkf_workflow_lifecycle',
+    applicationId,
+    runId: '',
+    deploymentVersion: 'v1',
+    payload: JSON.stringify({}),
+    payloadBytes: null,
+    payloadEncoding: 'json',
+  })
+
+  it('leaves an acknowledged delivery alone when reclaim runs', async () => {
+    const runId = `wrun_ack_${randomBytes(6).toString('hex')}`
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, spec_version)
+       VALUES ($1, $2, 'lifecycle', 'v1', 'running', 7)`,
+      [runId, applicationId]
+    )
+    const { messageId } = await store.enqueue({
+      queueName: '__wkf_workflow_lifecycle',
+      applicationId,
+      runId,
+      deploymentVersion: 'v1',
+      payload: JSON.stringify({ runId }),
+      payloadBytes: null,
+      payloadEncoding: 'json',
+    })
+    const msg = await store.claimForDispatch(messageId)
+    await store.ack(msg!)
+
+    // The run is still going, as a long workflow's would be. A successful
+    // delivery must not be resurrected once the visibility timeout passes.
+    await ctx.app.pg.query(
+      "UPDATE workflow_queue_messages SET delivered_at = NOW() - interval '20 minutes' WHERE id = $1",
+      [messageId]
+    )
+    const client = await ctx.app.pg.connect()
+    try {
+      assert.equal(await reclaimExpiredDeliveries(client, silentLog, 60), 0)
+    } finally {
+      client.release()
+    }
+    const row = (await ctx.app.pg.query(
+      'SELECT status, acked_at FROM workflow_queue_messages WHERE id = $1', [messageId]
+    )).rows[0]
+    assert.equal(row.status, 'acked')
+    assert.ok(row.acked_at)
+  })
+
+  it('makes a message dispatchable again after a dispatch task throws', async () => {
+    const { messageId } = await enqueue()
+    for (const entry of await store.takeUnpublished(10)) {
+      await transport.publish(entry.messageId, entry)
+      await store.markPublished(entry.messageId)
+    }
+    const [leased] = (await transport.receive(50)).filter(m => String(m.messageId) === String(messageId))
+    assert.ok(leased, 'the message was offered')
+    assert.ok(!(await transport.receive(50)).some(m => String(m.messageId) === String(messageId)),
+      'a leased message is not offered twice')
+
+    // The full failure path, both layers: the task claims, then throws before
+    // recording any outcome. Releasing only the transport lease is not enough
+    // -- the store row would still be 'delivered', so the redelivery would lose
+    // claimForDispatch and be acked without ever executing.
+    const claimed = await store.claimForDispatch(messageId)
+    assert.ok(claimed, 'the task claimed the message')
+    await store.releaseClaim(claimed!)
+    await transport.release(leased.leaseId)
+
+    const reoffered = (await transport.receive(50)).filter(m => String(m.messageId) === String(messageId))
+    assert.equal(reoffered.length, 1, 'a released message is offered again')
+    const reclaimed = await store.claimForDispatch(messageId)
+    assert.ok(reclaimed, 'and the store lets the redelivery actually run')
+    assert.equal(reclaimed!.attempts, 0, 'no delivery happened, so no attempt was spent')
+  })
+
+  it('keeps a continuation and its acknowledgement in one transaction', async () => {
+    const { messageId } = await enqueue()
+    const claimed = await store.claimForDispatch(messageId)
+    await store.ack(claimed!, { delaySeconds: 0 })
+
+    const original = (await ctx.app.pg.query(
+      'SELECT status FROM workflow_queue_messages WHERE id = $1', [messageId]
+    )).rows[0]
+    assert.equal(original.status, 'acked')
+    const continuations = await ctx.app.pg.query(
+      `SELECT id, published_at FROM workflow_queue_messages
+       WHERE queue_name = $1 AND id <> $2 AND status = 'pending'`,
+      [claimed!.queue_name, messageId]
+    )
+    assert.equal(continuations.rows.length, 1, 'the continuation committed with the ack')
+    assert.equal(continuations.rows[0].published_at, null, 'and goes through the outbox')
+  })
+
+  it('returns a retried dead letter to the outbox', async () => {
+    const runId = `wrun_dl_${randomBytes(6).toString('hex')}`
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_runs (id, application_id, workflow_name, deployment_id, status, spec_version)
+       VALUES ($1, $2, 'deadletter', 'v1', 'running', 7)`,
+      [runId, applicationId]
+    )
+    const { messageId } = await store.enqueue({
+      queueName: '__wkf_workflow_deadletter',
+      applicationId,
+      runId,
+      deploymentVersion: 'v1',
+      payload: JSON.stringify({ runId }),
+      payloadBytes: null,
+      payloadEncoding: 'json',
+    })
+    // Dead, but not finalized, which is what the retry endpoint accepts.
+    await ctx.app.pg.query(
+      `UPDATE workflow_queue_messages
+       SET status = 'dead', dead_at = NOW(), published_at = NOW(), failure_finalized_at = NULL
+       WHERE id = $1`,
+      [messageId]
+    )
+
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/dead-letters/msg_${messageId}/retry`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+    })
+    assert.equal(res.statusCode, 200)
+
+    const row = (await ctx.app.pg.query(
+      'SELECT status, published_at FROM workflow_queue_messages WHERE id = $1', [messageId]
+    )).rows[0]
+    assert.equal(row.status, 'pending')
+    // Its broker copy was acked when it died, so it has to be published again.
+    assert.equal(row.published_at, null)
+  })
+})
+
+describe('queue coordinator', () => {
+  it('announces leadership so a broker-distributed backend actually drains', async () => {
+    // The poller only starts draining when the callback reports true. A
+    // coordinator that never calls it leaves the queue silently unconsumed,
+    // which is what an always-leader constant did.
+    const { createAlwaysLeaderCoordinator } = await import('../queue/coordinator.ts')
+    const seen: boolean[] = []
+    const coordinator = createAlwaysLeaderCoordinator(isLeader => seen.push(isLeader))
+
+    assert.deepEqual(seen, [], 'nothing announced before start')
+    coordinator.start()
+    assert.deepEqual(seen, [true], 'leadership announced on start')
+    assert.equal(coordinator.isLeader(), true)
+    await coordinator.stop()
+    assert.deepEqual(seen, [true, false], 'and relinquished on stop')
+  })
+})
+
+describe('queue driver change', () => {
+  let ctx: TestContext
+  let applicationId: number
+
+  before(async () => {
+    ctx = await setupTest()
+    const app = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+    )
+    applicationId = app.rows[0].id
+  })
+
+  after(async () => { await teardownTest(ctx) })
+
+  it('republishes pending messages when the transport changes underneath them', async () => {
+    const { createPostgresQueueStore } = await import('../queue/stores/postgres.ts')
+    const onPostgres = createPostgresQueueStore(ctx.app.pg, silentLog, 'postgres')
+
+    const { messageId } = await onPostgres.enqueue({
+      queueName: '__wkf_workflow_driver-change',
+      applicationId,
+      runId: '',
+      deploymentVersion: 'v1',
+      payload: JSON.stringify({}),
+      payloadBytes: null,
+      payloadEncoding: 'json',
+    })
+
+    // Delivered to the transport that was running at the time.
+    for (const entry of await onPostgres.takeUnpublished(100)) {
+      await onPostgres.markPublished(entry.messageId)
+    }
+    assert.ok(!(await onPostgres.takeUnpublished(100)).some(e => String(e.messageId) === String(messageId)),
+      'settled against the transport that published it')
+    const row = (await ctx.app.pg.query(
+      'SELECT published_to FROM workflow_queue_messages WHERE id = $1', [messageId]
+    )).rows[0]
+    assert.equal(row.published_to, 'postgres')
+
+    // WF_QUEUE_DRIVER changes. The message was never sent to this broker, so
+    // being marked published is not enough: it has to go again, or it is
+    // stranded for good.
+    const onRedis = createPostgresQueueStore(ctx.app.pg, silentLog, 'redis')
+    assert.ok((await onRedis.takeUnpublished(100)).some(e => String(e.messageId) === String(messageId)),
+      'a pending message is re-offered to the new transport')
+
+    await onRedis.markPublished(messageId)
+    assert.ok(!(await onRedis.takeUnpublished(100)).some(e => String(e.messageId) === String(messageId)),
+      'and settles once the new transport has it')
+  })
+})

--- a/packages/workflow/test/queue.test.ts
+++ b/packages/workflow/test/queue.test.ts
@@ -233,6 +233,25 @@ describe('spec alignment', () => {
     // A namespace must be lowercase alphanumeric starting with a letter.
     assert.ok(!isWorkflowQueue('__9bad_wkf_workflow_greet'))
 
+    // An invalid WORKFLOW_QUEUE_NAMESPACE must fail loudly where the prefix is
+    // built (as the spec's getQueueTopicPrefix does), not silently produce a
+    // name that routes to the webhook handler.
+    const { workflowQueueName } = await import('../queue/names.ts')
+    const previousNs = process.env.WORKFLOW_QUEUE_NAMESPACE
+    try {
+      process.env.WORKFLOW_QUEUE_NAMESPACE = 'acme'
+      assert.equal(workflowQueueName('greet'), '__acme_wkf_workflow_greet')
+      for (const bad of ['Bad_Name', '9lives', 'has-dash', 'UPPER']) {
+        process.env.WORKFLOW_QUEUE_NAMESPACE = bad
+        assert.throws(() => workflowQueueName('greet'), /WORKFLOW_QUEUE_NAMESPACE/)
+      }
+      delete process.env.WORKFLOW_QUEUE_NAMESPACE
+      assert.equal(workflowQueueName('greet'), '__wkf_workflow_greet')
+    } finally {
+      if (previousNs === undefined) delete process.env.WORKFLOW_QUEUE_NAMESPACE
+      else process.env.WORKFLOW_QUEUE_NAMESPACE = previousNs
+    }
+
     // A continuation stays in the namespace the original arrived on.
     assert.equal(workflowQueueNameLike('__acme_wkf_workflow_greet', 'other'), '__acme_wkf_workflow_other')
     assert.equal(workflowQueueNameLike('__acme_wkf_step_add', 'other'), '__acme_wkf_workflow_other')
@@ -281,5 +300,37 @@ describe('spec alignment', () => {
       },
     })
     assert.equal(draining.statusCode, 201)
+  })
+
+  it('still dedupes an already-accepted message after its version expires', async () => {
+    // A retry of a message we already enqueued must answer 409, which the SDK
+    // reads as successful deduplication. Answering 410 would tell it the
+    // delivery is terminally undeliverable and could fail a healthy run.
+    const appRow = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+    )
+    const key = `idem-${randomBytes(8).toString('hex')}`
+    const send = () => ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/queue`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        queueName: '__wkf_workflow_dedupe-after-expiry',
+        message: { runId: 'wrun_dedupe' },
+        deploymentId: 'v-dedupe',
+        idempotencyKey: key,
+      },
+    })
+
+    assert.equal((await send()).statusCode, 201)
+
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_deployment_versions (application_id, deployment_version, status)
+       VALUES ($1, 'v-dedupe', 'expired')
+       ON CONFLICT (application_id, deployment_version) DO UPDATE SET status = 'expired'`,
+      [appRow.rows[0].id]
+    )
+
+    assert.equal((await send()).statusCode, 409)
   })
 })

--- a/packages/workflow/test/queue.test.ts
+++ b/packages/workflow/test/queue.test.ts
@@ -211,3 +211,75 @@ describe('queue', () => {
     assert.equal(response.statusCode, 409)
   })
 })
+
+describe('spec alignment', () => {
+  let ctx: TestContext
+
+  before(async () => { ctx = await setupTest() })
+  after(async () => { await teardownTest(ctx) })
+
+  it('routes namespaced queue names by the spec grammar, not a bare prefix', async () => {
+    // The spec allows __{namespace}_wkf_workflow_<id> (WORKFLOW_QUEUE_NAMESPACE).
+    // Matching the un-namespaced literal sent these to the webhook handler.
+    const { isWorkflowQueue, isStepQueue, workflowNameFromQueue, workflowQueueNameLike } =
+      await import('../queue/names.ts')
+
+    assert.ok(isWorkflowQueue('__wkf_workflow_greet'))
+    assert.ok(isWorkflowQueue('__acme_wkf_workflow_greet'))
+    assert.equal(workflowNameFromQueue('__acme_wkf_workflow_greet'), 'greet')
+    assert.ok(isStepQueue('__acme_wkf_step_add'))
+    assert.ok(!isWorkflowQueue('__acme_wkf_step_add'))
+    assert.ok(!isWorkflowQueue('webhook'))
+    // A namespace must be lowercase alphanumeric starting with a letter.
+    assert.ok(!isWorkflowQueue('__9bad_wkf_workflow_greet'))
+
+    // A continuation stays in the namespace the original arrived on.
+    assert.equal(workflowQueueNameLike('__acme_wkf_workflow_greet', 'other'), '__acme_wkf_workflow_other')
+    assert.equal(workflowQueueNameLike('__acme_wkf_step_add', 'other'), '__acme_wkf_workflow_other')
+    assert.equal(workflowQueueNameLike('webhook', 'other'), '__wkf_workflow_other')
+  })
+
+  it('refuses to enqueue for an expired deployment version', async () => {
+    const appRow = await ctx.app.pg.query(
+      'SELECT id FROM workflow_applications WHERE app_id = $1', [ctx.appId]
+    )
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_deployment_versions (application_id, deployment_version, status)
+       VALUES ($1, 'v-expired', 'expired')
+       ON CONFLICT (application_id, deployment_version) DO UPDATE SET status = 'expired'`,
+      [appRow.rows[0].id]
+    )
+
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/queue`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        queueName: '__wkf_workflow_expired-version',
+        message: { runId: 'wrun_expired' },
+        deploymentId: 'v-expired',
+      },
+    })
+    // 410 is what the World client reports through isDeploymentUnavailableError.
+    assert.equal(res.statusCode, 410)
+
+    // A draining version still accepts work, matching routeMessage().
+    await ctx.app.pg.query(
+      `INSERT INTO workflow_deployment_versions (application_id, deployment_version, status)
+       VALUES ($1, 'v-draining', 'draining')
+       ON CONFLICT (application_id, deployment_version) DO UPDATE SET status = 'draining'`,
+      [appRow.rows[0].id]
+    )
+    const draining = await ctx.app.inject({
+      method: 'POST',
+      url: `/api/v1/apps/${ctx.appId}/queue`,
+      headers: { authorization: `Bearer ${ctx.apiKey}` },
+      payload: {
+        queueName: '__wkf_workflow_draining-version',
+        message: { runId: 'wrun_draining' },
+        deploymentId: 'v-draining',
+      },
+    })
+    assert.equal(draining.statusCode, 201)
+  })
+})

--- a/packages/world/src/lib/queue.ts
+++ b/packages/world/src/lib/queue.ts
@@ -118,5 +118,14 @@ export function createQueue (client: HttpClient, config: QueueConfig) {
     return config.deploymentVersion
   }
 
-  return { queue, createQueueHandler, getDeploymentId }
+  // Spec hook (@workflow/world Queue): true only when the error definitively
+  // means the targeted deployment cannot receive the message, so the SDK can
+  // re-route instead of retrying. The workflow service answers 410
+  // (WF_VERSION_EXPIRED) for exactly that case; every other status, including
+  // transport failures with no status at all, stays retryable.
+  const isDeploymentUnavailableError = (error: unknown): boolean => {
+    return (error as { statusCode?: number } | null)?.statusCode === 410
+  }
+
+  return { queue, createQueueHandler, getDeploymentId, isDeploymentUnavailableError }
 }


### PR DESCRIPTION
## Summary

- Split queue processing into durable `QueueStore`, `BrokerTransport`, and `Coordinator` interfaces.
- Keep PostgreSQL as the default store and transport, preserving the current behavior.
- Add an outbox handoff with transport-aware publication tracking so pending messages survive crashes and queue-driver changes.
- Move delivery state transitions behind the store, including acknowledgement, retry, dead-letter, claim release, and expired-delivery recovery.
- Add backend conformance, redelivery, leadership, outbox, and driver-change coverage.

## Dependency

This PR is stacked on [#176](https://github.com/platformatic/platformatic-world/pull/176), which has not been merged yet. Review and merge #176 first. 

This introduces the extension points and retains PostgreSQL behavior. External Redis or SQS transports are intentionally left for the next phase.
